### PR TITLE
2023 11 02

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,8 @@
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/typeorm": "^10.0.0",
         "bcrypt": "^5.1.1",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.0",
         "pg": "^8.11.3",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.8.1",
@@ -2299,6 +2301,11 @@
         "@types/superagent": "*"
       }
     },
+    "node_modules/@types/validator": {
+      "version": "13.11.5",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.5.tgz",
+      "integrity": "sha512-xW4qsT4UIYILu+7ZrBnfQdBYniZrMLYYK3wN9M/NdeIHgBN5pZI2/8Q7UfdWIcr5RLJv/OGENsx91JIpUUoC7Q=="
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.29",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
@@ -3469,6 +3476,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.3.tgz",
       "integrity": "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.0.tgz",
+      "integrity": "sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==",
+      "dependencies": {
+        "@types/validator": "^13.7.10",
+        "libphonenumber-js": "^1.10.14",
+        "validator": "^13.7.0"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -6639,6 +6661,11 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.10.49",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.10.49.tgz",
+      "integrity": "sha512-gvLtyC3tIuqfPzjvYLH9BmVdqzGDiSi4VjtWe2fAgSdBf0yt8yPmbNnRIHNbR5IdtVkm0ayGuzwQKTWmU0hdjQ=="
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -9473,6 +9500,14 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.11.0.tgz",
+      "integrity": "sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.0",
     "bcrypt": "^5.1.1",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.0",
     "pg": "^8.11.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { ClassSerializerInterceptor, Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { PostsModule } from './posts/posts.module';
@@ -10,7 +10,13 @@ import { AuthModule } from './auth/auth.module';
 
 @Module({
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: 'APP_INTERCEPTOR',
+      useClass: ClassSerializerInterceptor,
+    },
+  ],
   imports: [
     PostsModule,
     UsersModule,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -2,6 +2,7 @@ import { Body, Controller, Post, UseGuards, Request } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { BasicTokenGuard } from './guard/basic-token.guard';
 import { RefreshTokenGuard } from './guard/bearer-token.guard';
+import { RegisterUserDto } from './dto/register-user.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -16,12 +17,8 @@ export class AuthController {
   }
 
   @Post('register/email')
-  registerEmail(
-    @Body('email') email: string,
-    @Body('password') password: string,
-    @Body('name') name: string,
-  ) {
-    return this.authService.registerWithEmail({ email, password, name });
+  registerEmail(@Body() registerUserDto: RegisterUserDto) {
+    return this.authService.registerWithEmail(registerUserDto);
   }
 
   @Post('token/access')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,15 +1,23 @@
-import { Body, Controller, Post, Headers } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Post,
+  Headers,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
 import { AuthService } from './auth.service';
+import { BasicTokenGuard } from './guard/basic-token.guard';
 
 @Controller('auth')
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('login/email')
-  loginEmail(@Headers('Authorization') authorization: string) {
-    const token = this.authService.extractTokenFromHeader(authorization, false);
-    const { email, password } = this.authService.decodeBasicToken(token);
-
+  @UseGuards(BasicTokenGuard)
+  loginEmail(@Headers('Authorization') authorization: string, @Request() req) {
+    const email = req.user.email;
+    const password = req.user.password;
     return this.authService.loginWithEmail({ email, password });
   }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,13 +1,7 @@
-import {
-  Body,
-  Controller,
-  Post,
-  Headers,
-  UseGuards,
-  Request,
-} from '@nestjs/common';
+import { Body, Controller, Post, UseGuards, Request } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { BasicTokenGuard } from './guard/basic-token.guard';
+import { RefreshTokenGuard } from './guard/bearer-token.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -15,7 +9,7 @@ export class AuthController {
 
   @Post('login/email')
   @UseGuards(BasicTokenGuard)
-  loginEmail(@Headers('Authorization') authorization: string, @Request() req) {
+  loginEmail(@Request() req) {
     const email = req.user.email;
     const password = req.user.password;
     return this.authService.loginWithEmail({ email, password });
@@ -31,9 +25,9 @@ export class AuthController {
   }
 
   @Post('token/access')
-  getAccessToken(@Headers('Authorization') authorization: string) {
-    const token = this.authService.extractTokenFromHeader(authorization, true);
-    const newToken = this.authService.rotateToken(token, false);
+  @UseGuards(RefreshTokenGuard)
+  getAccessToken(@Request() req) {
+    const newToken = this.authService.rotateToken(req.token, false);
 
     return {
       accessToken: newToken,
@@ -41,9 +35,9 @@ export class AuthController {
   }
 
   @Post('token/refresh')
-  getRefreshToken(@Headers('Authorization') authorization: string) {
-    const token = this.authService.extractTokenFromHeader(authorization, true);
-    const newToken = this.authService.rotateToken(token, true);
+  @UseGuards(RefreshTokenGuard)
+  getRefreshToken(@Request() req) {
+    const newToken = this.authService.rotateToken(req.token, true);
 
     return {
       refreshToken: newToken,

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -8,5 +8,6 @@ import { UsersModule } from 'src/users/users.module';
   controllers: [AuthController],
   providers: [AuthService],
   imports: [JwtModule.register({}), UsersModule],
+  exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -99,9 +99,7 @@ export class AuthService {
   }
 
   rotateToken(token: string, isRefreshToken: boolean) {
-    const decoded = this.jwtService.verify(token, {
-      secret: 'secret',
-    });
+    const decoded = this.verifyToken(token);
 
     if (decoded.type !== 'refresh') {
       throw new UnauthorizedException(
@@ -118,8 +116,12 @@ export class AuthService {
   }
 
   verifyToken(token: string) {
-    return this.jwtService.verify(token, {
-      secret: 'secret',
-    });
+    try {
+      return this.jwtService.verify(token, {
+        secret: 'secret',
+      });
+    } catch (e) {
+      throw new UnauthorizedException('token is expired or invalid token');
+    }
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { User } from 'src/users/entities/user.entity';
 import { UsersService } from 'src/users/users.service';
 import * as bcrypt from 'bcrypt';
+import { RegisterUserDto } from './dto/register-user.dto';
 
 @Injectable()
 export class AuthService {
@@ -58,11 +59,14 @@ export class AuthService {
     return this.loginUser(exUser);
   }
 
-  async registerWithEmail(user: Pick<User, 'email' | 'name' | 'password'>) {
-    const hash = await bcrypt.hash(user.password, 12);
+  async registerWithEmail(registerUserDto: RegisterUserDto) {
+    const { name, email, password } = registerUserDto;
+
+    const hash = await bcrypt.hash(password, 12);
 
     const newUser = await this.usersService.create({
-      ...user,
+      name,
+      email,
       password: hash,
     });
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -116,4 +116,10 @@ export class AuthService {
       isRefreshToken,
     );
   }
+
+  verifyToken(token: string) {
+    return this.jwtService.verify(token, {
+      secret: 'secret',
+    });
+  }
 }

--- a/src/auth/dto/register-user.dto.ts
+++ b/src/auth/dto/register-user.dto.ts
@@ -1,0 +1,8 @@
+import { PickType } from '@nestjs/mapped-types';
+import { User } from 'src/users/entities/user.entity';
+
+export class RegisterUserDto extends PickType(User, [
+  'name',
+  'email',
+  'password',
+]) {}

--- a/src/auth/guard/basic-token.guard.ts
+++ b/src/auth/guard/basic-token.guard.ts
@@ -1,0 +1,33 @@
+import {
+  CanActivate,
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class BasicTokenGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const rawToken = req.headers.Authorization;
+
+    if (rawToken) {
+      throw new UnauthorizedException('No token provided');
+    }
+
+    const token = this.authService.extractTokenFromHeader(rawToken, false);
+    const { email, password } = this.authService.decodeBasicToken(token);
+
+    const user = await this.authService.authenticateWithEmailAndPassword({
+      email,
+      password,
+    });
+
+    req.user = user;
+
+    return true;
+  }
+}

--- a/src/auth/guard/bearer-token.guard.ts
+++ b/src/auth/guard/bearer-token.guard.ts
@@ -1,0 +1,65 @@
+import {
+  CanActivate,
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+import { UsersService } from 'src/users/users.service';
+
+@Injectable()
+class BearerTokenGuard implements CanActivate {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const rawToken = req.headers.authorization;
+
+    if (rawToken) {
+      throw new UnauthorizedException('No token provided');
+    }
+
+    const token = this.authService.extractTokenFromHeader(rawToken, true);
+    const decode = await this.authService.verifyToken(token);
+    const user = await this.usersService.getUserByEmail(decode.email);
+
+    req.token = token;
+    req.tokenType = decode.type;
+    req.user = user;
+
+    return true;
+  }
+}
+
+@Injectable()
+export class AccessTokenGuard extends BearerTokenGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (req.tokenType !== 'access') {
+      throw new UnauthorizedException('this is not access token');
+    }
+
+    return true;
+  }
+}
+
+@Injectable()
+export class RefreshTokenGuard extends BearerTokenGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (req.tokenType !== 'refresh') {
+      throw new UnauthorizedException('this is not refresh token');
+    }
+
+    return true;
+  }
+}

--- a/src/common/entities/base.entity.ts
+++ b/src/common/entities/base.entity.ts
@@ -1,0 +1,16 @@
+import {
+  CreateDateColumn,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export abstract class Base {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/common/validation-message/email.validation.message.ts
+++ b/src/common/validation-message/email.validation.message.ts
@@ -1,0 +1,5 @@
+import { ValidationArguments } from 'class-validator';
+
+export const emailValidationMessage = (args: ValidationArguments) => {
+  return `${args.property} must be an email`;
+};

--- a/src/common/validation-message/length-validation.message.ts
+++ b/src/common/validation-message/length-validation.message.ts
@@ -1,0 +1,9 @@
+import { ValidationArguments } from 'class-validator';
+
+export const lengthValidationMessage = (args: ValidationArguments) => {
+  if (args.constraints.length == 1) {
+    return `${args.property} must be longer than ${args.constraints[0]} characters`;
+  } else {
+    return `${args.property} must be longer than ${args.constraints[0]} and shorter than ${args.constraints[1]} characters`;
+  }
+};

--- a/src/common/validation-message/string-validation.message.ts
+++ b/src/common/validation-message/string-validation.message.ts
@@ -1,0 +1,5 @@
+import { ValidationArguments } from 'class-validator';
+
+export const stringValidationMessage = (args: ValidationArguments) => {
+  return `${args.property} must be a string`;
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(new ValidationPipe());
+
   await app.listen(3000);
 }
 bootstrap();

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,14 @@ import { ValidationPipe } from '@nestjs/common';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    }),
+  );
 
   await app.listen(3000);
 }

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,4 +1,9 @@
+import { IsString } from 'class-validator';
+
 export class CreatePostDto {
+  @IsString({ message: 'Content must be a string' })
   content: string;
+
+  @IsString({ message: 'Title must be a string' })
   title: string;
 }

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,5 +1,4 @@
 export class CreatePostDto {
-  userId: number;
   content: string;
   title: string;
 }

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,9 +1,4 @@
-import { IsString } from 'class-validator';
+import { PickType } from '@nestjs/mapped-types';
+import { Post } from '../entities/post.entity';
 
-export class CreatePostDto {
-  @IsString({ message: 'Content must be a string' })
-  content: string;
-
-  @IsString({ message: 'Title must be a string' })
-  title: string;
-}
+export class CreatePostDto extends PickType(Post, ['title', 'content']) {}

--- a/src/posts/dto/paginate-post.dto.ts
+++ b/src/posts/dto/paginate-post.dto.ts
@@ -1,0 +1,19 @@
+import { IsIn, IsNumber, IsOptional } from 'class-validator';
+
+export class PaginatePostDto {
+  @IsNumber()
+  @IsOptional()
+  where__id_more_than?: number;
+
+  @IsNumber()
+  @IsOptional()
+  where__id_less_than?: number;
+
+  @IsIn(['ASC', 'DESC'])
+  @IsOptional()
+  order__createdAt: 'ASC' | 'DESC' = 'ASC';
+
+  @IsNumber()
+  @IsOptional()
+  take: number = 20;
+}

--- a/src/posts/dto/update-post.dto.ts
+++ b/src/posts/dto/update-post.dto.ts
@@ -1,7 +1,13 @@
 import { PartialType } from '@nestjs/mapped-types';
 import { CreatePostDto } from './create-post.dto';
+import { IsOptional, IsString } from 'class-validator';
 
 export class UpdatePostDto extends PartialType(CreatePostDto) {
-  content: string;
-  title: string;
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  content?: string;
 }

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -1,3 +1,4 @@
+import { IsString } from 'class-validator';
 import { Base } from 'src/common/entities/base.entity';
 import { User } from 'src/users/entities/user.entity';
 import { Column, Entity, ManyToOne } from 'typeorm';
@@ -8,9 +9,11 @@ export class Post extends Base {
   author: string;
 
   @Column('text')
+  @IsString({ message: 'Content must be a string' })
   content: string;
 
   @Column({ length: 100 })
+  @IsString({ message: 'Title must be a string' })
   title: string;
 
   @ManyToOne(() => User, (user) => user.posts)

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -5,9 +5,6 @@ import { Column, Entity, ManyToOne } from 'typeorm';
 
 @Entity({ name: 'posts' })
 export class Post extends Base {
-  @Column({ length: 500 })
-  author: string;
-
   @Column('text')
   @IsString({ message: 'Content must be a string' })
   content: string;

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -1,11 +1,9 @@
+import { Base } from 'src/common/entities/base.entity';
 import { User } from 'src/users/entities/user.entity';
 import { Column, Entity, ManyToOne } from 'typeorm';
 
 @Entity({ name: 'posts' })
-export class Post {
-  @Column({ primary: true, generated: true })
-  id: number;
-
+export class Post extends Base {
   @Column({ length: 500 })
   author: string;
 
@@ -14,12 +12,6 @@ export class Post {
 
   @Column({ length: 100 })
   title: string;
-
-  @Column({ default: new Date() })
-  createdAt: Date;
-
-  @Column({ default: new Date() })
-  updatedAt: Date;
 
   @ManyToOne(() => User, (user) => user.posts)
   user: User;

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -1,16 +1,17 @@
 import { IsString } from 'class-validator';
 import { Base } from 'src/common/entities/base.entity';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 import { User } from 'src/users/entities/user.entity';
 import { Column, Entity, ManyToOne } from 'typeorm';
 
 @Entity({ name: 'posts' })
 export class Post extends Base {
   @Column('text')
-  @IsString({ message: 'Content must be a string' })
+  @IsString({ message: stringValidationMessage })
   content: string;
 
   @Column({ length: 100 })
-  @IsString({ message: 'Title must be a string' })
+  @IsString({ message: stringValidationMessage })
   title: string;
 
   @ManyToOne(() => User, (user) => user.posts)

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -6,13 +6,13 @@ import {
   Patch,
   Param,
   Delete,
-  Request,
   UseGuards,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
+import { User } from 'src/users/decorators/user.decorator';
 
 @Controller('posts')
 export class PostsController {
@@ -20,8 +20,8 @@ export class PostsController {
 
   @Post('/create')
   @UseGuards(AccessTokenGuard)
-  create(@Request() req, @Body() createPostDto: CreatePostDto) {
-    return this.postsService.create(createPostDto, req.user.id);
+  create(@User('id') id, @Body() createPostDto: CreatePostDto) {
+    return this.postsService.create(createPostDto, id);
   }
 
   @Get()

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -7,12 +7,14 @@ import {
   Param,
   Delete,
   UseGuards,
+  Query,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { User } from 'src/users/decorators/user.decorator';
+import { PaginatePostDto } from './dto/paginate-post.dto';
 
 @Controller('posts')
 export class PostsController {
@@ -25,8 +27,8 @@ export class PostsController {
   }
 
   @Get()
-  findAll() {
-    return this.postsService.findAll();
+  findAll(@Query() paginatePostDto: PaginatePostDto) {
+    return this.postsService.pagenatePosts(paginatePostDto);
   }
 
   @Get(':id')

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -6,18 +6,22 @@ import {
   Patch,
   Param,
   Delete,
+  Request,
+  UseGuards,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 
 @Controller('posts')
 export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Post('/create')
-  create(@Body() createPostDto: CreatePostDto) {
-    return this.postsService.create(createPostDto);
+  @UseGuards(AccessTokenGuard)
+  create(@Request() req, @Body() createPostDto: CreatePostDto) {
+    return this.postsService.create(createPostDto, req.user.id);
   }
 
   @Get()

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -3,10 +3,12 @@ import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
+import { AuthModule } from 'src/auth/auth.module';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
   controllers: [PostsController],
   providers: [PostsService],
-  imports: [TypeOrmModule.forFeature([Post])],
+  imports: [TypeOrmModule.forFeature([Post]), AuthModule, UsersModule],
 })
 export class PostsModule {}

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -3,7 +3,8 @@ import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
-import { Repository } from 'typeorm';
+import { LessThan, MoreThan, Repository } from 'typeorm';
+import { PaginatePostDto } from './dto/paginate-post.dto';
 
 @Injectable()
 export class PostsService {
@@ -63,5 +64,68 @@ export class PostsService {
     }
 
     return this.postsRepository.remove(post);
+  }
+
+  async pagenatePosts(paginatePostDto: PaginatePostDto) {
+    const { where__id_more_than, where__id_less_than, order__createdAt, take } =
+      paginatePostDto;
+
+    if (where__id_more_than && where__id_less_than) {
+      throw new Error(
+        'where__id_more_than and where__id_less_than cannot be used at the same time',
+      );
+    }
+
+    const getId = () => {
+      if (where__id_more_than) return MoreThan(where__id_more_than);
+      else if (where__id_less_than) return LessThan(where__id_less_than);
+      else {
+        if (order__createdAt == 'ASC') return MoreThan(0);
+        else return LessThan(Infinity);
+      }
+    };
+
+    const posts = await this.postsRepository.find({
+      where: {
+        id: getId(),
+      },
+      order: {
+        createdAt: order__createdAt,
+      },
+      take,
+    });
+
+    const lastItem = posts.length > 0 ? posts[posts.length - 1] : null;
+    const nextUrl = lastItem ? new URL('http://localhost:3000/posts') : null;
+    if (nextUrl) {
+      for (const key of Object.keys(paginatePostDto)) {
+        if (!paginatePostDto[key]) continue;
+
+        if (key != 'where__id_more_than' && key != 'where__id_less_than') {
+          nextUrl.searchParams.append(key, paginatePostDto[key]);
+        }
+      }
+
+      if (paginatePostDto.order__createdAt == 'ASC') {
+        nextUrl.searchParams.append(
+          'where__id_more_than',
+          lastItem.id.toString(),
+        );
+      } else {
+        nextUrl.searchParams.append(
+          'where__id_less_than',
+          lastItem.id.toString(),
+        );
+      }
+    }
+
+    return {
+      data: posts,
+      cursor: {
+        after: lastItem?.id,
+      },
+      count: posts?.length,
+      next: nextUrl?.toString(),
+    };
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -11,10 +11,10 @@ export class PostsService {
     @InjectRepository(Post) private readonly postsRepository: Repository<Post>,
   ) {}
 
-  async create(createPostDto: CreatePostDto) {
+  async create(createPostDto: CreatePostDto, userId: number) {
     const post = this.postsRepository.create({
       user: {
-        id: createPostDto.userId,
+        id: userId,
       },
       content: createPostDto.content,
       title: createPostDto.title,

--- a/src/users/decorators/user.decorator.ts
+++ b/src/users/decorators/user.decorator.ts
@@ -1,0 +1,26 @@
+import {
+  ExecutionContext,
+  InternalServerErrorException,
+  createParamDecorator,
+} from '@nestjs/common';
+
+export const User = createParamDecorator(
+  (data: string, context: ExecutionContext) => {
+    const req = context.switchToHttp().getRequest();
+
+    if (!req.user) {
+      throw new InternalServerErrorException('there is no user on the request');
+    }
+
+    switch (data) {
+      case 'id':
+        return req.user.id;
+      case 'email':
+        return req.user.email;
+      case 'role':
+        return req.user.role;
+      default:
+        return req.user;
+    }
+  },
+);

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -7,7 +7,7 @@ enum Role {
   ADMIN = 'admin',
 }
 
-@Entity()
+@Entity({ name: 'users' })
 export class User extends Base {
   @Column({ length: 500, unique: true })
   name: string;

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { IsEmail, IsString, Length } from 'class-validator';
 import { Base } from 'src/common/entities/base.entity';
 import { Post } from 'src/posts/entities/post.entity';
 import { Column, Entity, OneToMany } from 'typeorm';
@@ -10,12 +11,18 @@ enum Role {
 @Entity({ name: 'users' })
 export class User extends Base {
   @Column({ length: 500, unique: true })
+  @IsString()
+  @Length(1, 20)
   name: string;
 
   @Column({ length: 500 })
+  @IsString()
+  @IsEmail()
   email: string;
 
   @Column({ length: 500 })
+  @IsString()
+  @Length(3, 8)
   password: string;
 
   @Column({ type: 'enum', enum: Role, default: Role.USER })

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,5 +1,8 @@
 import { IsEmail, IsString, Length } from 'class-validator';
 import { Base } from 'src/common/entities/base.entity';
+import { emailValidationMessage } from 'src/common/validation-message/email.validation.message';
+import { lengthValidationMessage } from 'src/common/validation-message/length-validation.message';
+import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 import { Post } from 'src/posts/entities/post.entity';
 import { Column, Entity, OneToMany } from 'typeorm';
 
@@ -11,18 +14,31 @@ enum Role {
 @Entity({ name: 'users' })
 export class User extends Base {
   @Column({ length: 500, unique: true })
-  @IsString()
-  @Length(1, 20)
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @Length(1, 20, {
+    message: lengthValidationMessage,
+  })
   name: string;
 
   @Column({ length: 500 })
-  @IsString()
-  @IsEmail()
+  @IsString({
+    message: stringValidationMessage,
+  })
+  @IsEmail(
+    {},
+    {
+      message: emailValidationMessage,
+    },
+  )
   email: string;
 
   @Column({ length: 500 })
   @IsString()
-  @Length(3, 8)
+  @Length(3, 8, {
+    message: lengthValidationMessage,
+  })
   password: string;
 
   @Column({ type: 'enum', enum: Role, default: Role.USER })

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { Base } from 'src/common/entities/base.entity';
 import { Post } from 'src/posts/entities/post.entity';
 import { Column, Entity, OneToMany } from 'typeorm';
 
@@ -7,10 +8,7 @@ enum Role {
 }
 
 @Entity()
-export class User {
-  @Column({ primary: true, generated: true })
-  id: number;
-
+export class User extends Base {
   @Column({ length: 500, unique: true })
   name: string;
 
@@ -22,12 +20,6 @@ export class User {
 
   @Column({ type: 'enum', enum: Role, default: Role.USER })
   role: Role;
-
-  @Column({ default: new Date() })
-  createdAt: Date;
-
-  @Column({ default: new Date() })
-  updatedAt: Date;
 
   @OneToMany(() => Post, (post) => post.user)
   posts: Post[];

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -1,3 +1,4 @@
+import { Exclude } from 'class-transformer';
 import { IsEmail, IsString, Length } from 'class-validator';
 import { Base } from 'src/common/entities/base.entity';
 import { emailValidationMessage } from 'src/common/validation-message/email.validation.message';
@@ -38,6 +39,9 @@ export class User extends Base {
   @IsString()
   @Length(3, 8, {
     message: lengthValidationMessage,
+  })
+  @Exclude({
+    toPlainOnly: true,
   })
   password: string;
 

--- a/study/2023-11-02.md
+++ b/study/2023-11-02.md
@@ -1,0 +1,646 @@
+## Pipe
+
+파이프는 `PipeTransform` 인터페이스를 구현하는 `@Injectable()` 데코레이터로 주석이 달린 클래스입니다.
+![Alt text](https://docs.nestjs.com/assets/Pipe_1.png)
+
+파이프에는 두 가지 일반적인 사용 사례가 있습니다.
+
+**변환**: 입력 데이터를 원하는 형식으로 변환합니다(예: 문자열에서 정수로).
+**유효성 검사**: 입력 데이터를 평가하고 유효한 경우 변경하지 않고 그대로 전달합니다. 그렇지 않으면 예외를 발생시킵니다.
+
+### Built-in pipes
+
+Nest에는 기본적으로 사용 가능한 9개의 파이프가 함께 제공됩니다.
+
+- `ValidationPipe`
+- `ParseIntPipe`
+- `ParseFloatPipe`
+- `ParseBoolPipe`
+- `ParseArrayPipe`
+- `ParseUUIDPipe`
+- `ParseEnumPipe`
+- `DefaultValuePipe`
+- `ParseFilePipe`
+
+They're exported from the @nestjs/common package.
+
+어떻게 쓰는지 예제를 보자.
+
+```ts
+@Get(':id')
+getPost(@Param('id', ParseIntPipe) id: number) {
+  return this.postsService.findOne(id);
+}
+```
+
+이렇게, 파이프라인을 형성해서 값을 정수형으로 바꿔줄 수 있다.
+
+만약 정수형 문자열이 오지 않는다면, 예외를 발생시키고 그것을 클라이언트 측에 보내준다.
+
+```json
+{
+  "statusCode": 400,
+  "message": "Validation failed (numeric string is expected)",
+  "error": "Bad Request"
+}
+```
+
+이렇게 말이다. 물론, 내가 어떤 예외를 던질 지도 커스터마이징 해줄 수 있다.
+
+```ts
+@Get(':id')
+getPost(@Param('id', ParseIntPipe({errorHttpStatusCode: HttpStatus.NOT_ACCEPTABLE})) id: number) {
+  return this.postsService.findOne(id);
+}
+```
+
+이렇게 파이프 안에 옵션을 넣어주면 된다.
+
+`@ValidationPipe`의 예제도 한번 보자.
+
+```ts
+@Post()
+@UsePipes(ValidationPipe)
+create(@Body() createCatDto: CreateCatDto) {
+  this.catsService.create(createCatDto);
+}
+```
+
+### 커스텀 파이프
+
+그리고 커스텀 파이프도 만들 수 있다.
+
+예시를 보자.
+
+```ts
+@Injectable()
+class PasswordPipe implements PipeTransform {
+  transform(value: any, metadata: ArgumentMetadata) {
+    if (value.toString().length > 8) {
+      return new BadRequestException('Password is too long');
+    }
+
+    return value.toString();
+  }
+}
+```
+
+### DefalutValuePipe
+
+`DefaultValuePipe`는 파이프를 사용하지 않을 때 기본값을 설정할 수 있게 해준다.
+
+```ts
+@Get()
+findAll(@Query('page', new DefaultValuePipe(value)) page: number) {
+  return `This action returns all cats (limit: ${page} items)`;
+}
+```
+
+default 값은 `value`에 있는 값이 된다.
+
+### 여러개의 파이프 동시에 적용하기
+
+여러개의 파이프를 동시에 적용할 수 있다.
+
+```ts
+@Post()
+@UsePipes(new ValidationPipe(), new PasswordPipe())
+create(@Body() createUserDto: CreateUserDto) {
+  this.usersService.create(createUserDto);
+}
+```
+
+## 상속을 이용한 BaseModel Entity 만들기
+
+```ts
+import {
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+export class BaseModel {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+```
+
+이렇게 하면, 모든 엔티티가 이 엔티티를 상속받아서 사용할 수 있다.
+
+## pgAdmin 사용하기
+
+pgAdmin을 사용하면, 데이터베이스를 시각적으로 관리할 수 있다. 무료라서 좋당.
+다른 툴과 비슷하게, 연결하고 사용하면 된당
+
+## Guard 이론 및 구현할 스팩 정리
+
+`Guard`는 `@Injectable()` 데코레이터로 주석이 달린 클래스입니다. `CanActivate` 인터페이스를 구현해야합니다. `CanActivate` 인터페이스는 `ExecutionContext` 인스턴스를 사용하여 요청을 검사합니다. `ExecutionContext`에는 `switchToHttp()` 메서드가 있습니다. 이 메서드는 `getRequest()` 및 `getResponse()` 메서드를 사용하여 요청 및 응답 객체에 액세스 할 수있는 `HttpArgumentsHost` 인스턴스를 반환합니다.
+
+`auth/guard/basic-token.guard.ts`를 만들어서 가드를 써보자. `pipe`를 만드는 것과 매우 유사하니, 겁먹지 말자.
+
+```ts
+import {
+  CanActivate,
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+
+@Injectable()
+export class BasicTokenGuard implements CanActivate {
+  constructor(private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const rawToken = req.headers.Authorization;
+
+    if (rawToken) {
+      throw new UnauthorizedException('No token provided');
+    }
+
+    const token = this.authService.extractTokenFromHeader(rawToken, false);
+    const { email, password } = this.authService.decodeBasicToken(token);
+
+    const user = await this.authService.authenticateWithEmailAndPassword({
+      email,
+      password,
+    });
+
+    req.user = user;
+
+    return true;
+  }
+}
+```
+
+이렇게 만들었는데, 로직은 크게 어렵지 않으니 이해하리라 믿는다. 이렇게 가드를 작성하고
+
+```ts
+  @Post('login/email')
+  @UseGuards(BasicTokenGuard)
+  loginEmail(@Headers('Authorization') authorization: string, @Request() req) {
+    const email = req.user.email;
+    const password = req.user.password;
+    return this.authService.loginWithEmail({ email, password });
+  }
+```
+
+이렇게 써주면, 요청이 들어오면 저 위에 있는 가드 코드를 한번 통과하고, 만약 실패하면 에러를 던지겠지? 성공하면 req.user = user가 되어서, 이제 request에서 user 정보를 가져올 수 있게 된다. 참 간단하다. express와 닮은 게 있는 것 같다.
+
+`BasicTokenGuard`를 만들었으니, `BearerTokenGuard`도 만들어보자.
+
+```ts
+import {
+  CanActivate,
+  Injectable,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthService } from '../auth.service';
+import { UsersService } from 'src/users/users.service';
+
+@Injectable()
+class BearerTokenGuard implements CanActivate {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const req = context.switchToHttp().getRequest();
+    const rawToken = req.headers.authorization;
+
+    if (rawToken) {
+      throw new UnauthorizedException('No token provided');
+    }
+
+    const token = this.authService.extractTokenFromHeader(rawToken, true);
+    const decode = await this.authService.verifyToken(token);
+    const user = await this.usersService.getUserByEmail(decode.email);
+
+    req.token = token;
+    req.tokenType = decode.type;
+    req.user = user;
+
+    return true;
+  }
+}
+
+@Injectable()
+export class AccessTokenGuard extends BearerTokenGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (req.tokenType !== 'access') {
+      throw new UnauthorizedException('this is not access token');
+    }
+
+    return true;
+  }
+}
+
+@Injectable()
+export class RefreshTokenGuard extends BearerTokenGuard {
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    await super.canActivate(context);
+
+    const req = context.switchToHttp().getRequest();
+
+    if (req.tokenType !== 'refresh') {
+      throw new UnauthorizedException('this is not refresh token');
+    }
+
+    return true;
+  }
+}
+```
+
+위와 같이 만들었다. 로직은 크게 어렵지 않다. 잘 읽고 따라가보자. 이렇게 만든 것들을 이용해서, 컨트롤러를 다음과 같이 수정해줬다.
+
+```ts
+  @Post('token/access')
+  @UseGuards(RefreshTokenGuard)
+  getAccessToken(@Request() req) {
+    const newToken = this.authService.rotateToken(req.token, false);
+
+    return {
+      accessToken: newToken,
+    };
+  }
+
+  @Post('token/refresh')
+  @UseGuards(RefreshTokenGuard)
+  getRefreshToken(@Request() req) {
+    const newToken = this.authService.rotateToken(req.token, true);
+
+    return {
+      refreshToken: newToken,
+    };
+  }
+```
+
+정말 깔끔해졌다! 이제, 별 다른 절차 없이 가드만을 이용해서 토큰 재발급 여부를 수락하거나 거절할 수 있게 되었다. 그리고, req에 더 많은 정보를 포함하게 하여 요청 처리에 훨씬 편하게 되었다. `RefeshTokenGuard`로 토큰을 재발급 해주는 부분을 완성했으니, `AccessTokenGuard`를 이용하여 권한이 있는 사람만 접근할 수 있는 곳을 설정해주자.
+
+`posts controller` 중 하나의 엔드포인트를 다음과 같이 수정하였다.
+
+```ts
+  @Post('/create')
+  @UseGuards(AccessTokenGuard)
+  create(@Request() req, @Body() createPostDto: CreatePostDto) {
+    return this.postsService.create(createPostDto, req.user.id);
+  }
+```
+
+짠! 이제 AccessToken을 발급받아야만 글을 작성할 수 있게 되었다!
+
+## 커스텀 데코레이터
+
+이제 `AccessTokenGuard`로 접근을 제한할 수 있지만, user 정보를 가져오고 싶을 때 매번 req 객체에서 req.user를 참조해서 하기 귀찮을 수 있다. 이것을 그냥 컨트롤러 매개변수로 받을 수는 없을까??라고 생각한 당신을 위해 커스텀 데코레티어가 있다. 이것을 이용하면 쉽게 할 수 있다고 한다.
+
+```ts
+import {
+  ExecutionContext,
+  InternalServerErrorException,
+  createParamDecorator,
+} from '@nestjs/common';
+
+export const User = createParamDecorator(
+  (data: string, context: ExecutionContext) => {
+    const req = context.switchToHttp().getRequest();
+
+    if (!req.user) {
+      throw new InternalServerErrorException('there is no user on the request');
+    }
+
+    switch (data) {
+      case 'id':
+        return req.user.id;
+      case 'email':
+        return req.user.email;
+      case 'password':
+        return req.user.password;
+      default:
+        return req.user;
+    }
+  },
+);
+```
+
+이렇게 간단하게 데코레이터를 작성할 수 있다. 이것을 적용시켜서 반복되는 부분을 줄여보자!
+
+```ts
+  @Post('/create')
+  @UseGuards(AccessTokenGuard)
+  create(@User('id') id, @Body() createPostDto: CreatePostDto) {
+    return this.postsService.create(createPostDto, id);
+  }
+```
+
+짠! 요렇게 간단하게 사용할 수 있다는것!
+
+## Postman 기능 심화
+
+## class validator
+
+class validator는 `class-validator` 패키지를 이용해서 사용할 수 있다. 이것을 이용하면, DTO에 대한 유효성 검사를 쉽게 할 수 있다.
+
+```bash
+npm i class-validator class-transformer
+```
+
+```ts
+import { IsString } from 'class-validator';
+
+export class CreatePostDto {
+  @IsString({ message: 'Content must be a string' })
+  content: string;
+
+  @IsString({ message: 'Title must be a string' })
+  title: string;
+}
+```
+
+이렇게 create-post dto에 적용시킬 수 있따. 주의해야할 점은 class-validator를 사용하려면 main.ts에서 다음을 추가해줘야 한다.
+
+```ts
+import { ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(new ValidationPipe());
+  await app.listen(3000);
+}
+```
+
+ok? good
+
+그리고, DTO를 만들 때 PickType을 이용하면 굉장히 편리한데, 이것을 이용해서 DTO를 만들어보자.
+
+```ts
+import { PickType } from '@nestjs/swagger';
+
+export class CreatePostDto extends PickType(Post, ['title', 'content']) {}
+```
+
+이렇게 말이다. class validator는 그러면 entity 파일 해당하는 곳에 넣어주면 되겠지? ㅎㅎ
+
+`@IsOptional` 데코레이터를 이용하면, 필수가 아닌 값에 대해서도 유효성 검사를 할 수 있다.
+
+```ts
+import { PartialType } from '@nestjs/mapped-types';
+import { CreatePostDto } from './create-post.dto';
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdatePostDto extends PartialType(CreatePostDto) {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  content?: string;
+}
+```
+
+이렇게 update dto에 대해서 한번 적용시켜 봤다. 유용하게 쓰이겠군.
+그리고, `PartialType`은 `@nestjs/mapped-types` 패키지에서 제공하는 것이다. 이것을 이용하면, 기존의 타입을 상속받아서, 모든 필드를 선택적으로 만들어준다. 이것을 이용하면, DTO를 만들 때, 필드를 하나하나 다 적어줄 필요가 없어진다. 이것도 굉장히 유용하게 쓰일 것 같다.
+
+다른 `validator`도 많으니 사용해보자.
+`@IsEmail()`, `@Length()`도 사용해봤는데, 똑같으니깐 쓰진 않겠다.
+
+또, `validation messgae`를 일반화 할 수 있다. 언제 이걸 다 넣지 생각한 당신을 위한 것이다.
+
+```ts
+@Length(1, 20, {
+  message(args: ValidationArguments) {
+    if(args.contrains.length == 1){
+      return `${args.property} must be longer than ${args.constraints[0]} characters`
+    } else {
+      return `${args.property} must be longer than ${args.constraints[0]} and shorter than ${args.constraints[1]} characters`
+    }
+  },
+})
+title: string;
+```
+
+`ValidationArguments`의 매개변수
+1: value(입력한 값)
+2: constraints(제약 조건) ex) @Length(1, 20) 이면, [1, 20]이 들어온다.
+3: target(검증하는 class의 이름)
+4: object(검증하고 있는 객체)
+5: property(검증하고 있는 프로퍼티 이름)
+
+그래서 이걸 어떻게 일반화해??
+
+`common` 폴더에 `validation-message`라는 폴더를 만들고, 그 안에 `length-validation-message.ts`를 만들어서 다음과 같이 작성해준다.
+
+```ts
+import { ValidationArguments } from 'class-validator';
+
+export const lengthValidationMessage = (args: ValidationArguments) => {
+  if (args.constraints.length == 1) {
+    return `${args.property} must be longer than ${args.constraints[0]} characters`;
+  } else {
+    return `${args.property} must be longer than ${args.constraints[0]} and shorter than ${args.constraints[1]} characters`;
+  }
+};
+```
+
+자, 이제 만든 이 함수를 저기다가 넣어주면 된당!
+
+```ts
+@Length(1, 20, {
+  message: lengthValidationMessage,
+})
+title: string;
+```
+
+개꿀! `emailValidationMessage`, `stringValidationMessage`를 또 작성해주고, 다른 모든 entity의 validator message에 적용시켜 줬다!
+
+## class transformer
+
+`class transformer`는 만약 데이터를 조회할 때 특정 필드를 제외하고 싶다면 어떻게 해야할까? 이것을 이용하면 쉽게 할 수 있다.
+
+```ts
+  @Exclude()
+  password: string;
+```
+
+이렇게, 조인연산하여 가져올 때 `@Exclude()` 어노테이션을 적용하고, 엔드포인트에서 `password`를 가져오는 컨트롤러에
+`@UseInterceptors(ClassSerializerInterceptor)`를 적용시켜주면 된다.
+
+```ts
+  @Get('/me')
+  @UseGuards(AccessTokenGuard)
+  @UseInterceptors(ClassSerializerInterceptor)
+  getMe(@User() user: User) {
+    return user;
+  }
+```
+
+이렇게 말이다! 그러면, User 정보를 가져올 때 `password`는 제외하고 가져온다.
+이렇듯, 우리가 데이터를 `직렬화` or `역직렬화`할 때, `class transformer`를 사용하면, 특정 필드를 제외하거나, 특정 필드를 추가할 수 있다.
+
+`@Exclude()`의 옵션으로는 다음이 있다.
+
+- `toPlainOnly`: plainToClass()를 사용할 때 제외할 필드를 지정합니다.(직렬화)
+- `toClassOnly`: classToPlain()를 사용할 때 제외할 필드를 지정합니다.(역직렬화)
+
+`@Expose()`의 옵션으로는 다음이 있다.
+
+- `toPlainOnly`: plainToClass()를 사용할 때 노출할 필드를 지정합니다.(직렬화)
+- `toClassOnly`: classToPlain()를 사용할 때 노출할 필드를 지정합니다.(역직렬화)
+
+근데, 엔드포인트별로 다 넣을라그러면, 너무 힘들지 않을까? 라고 생각한 당신을 위해 글로벌하게 이 트렌스포머를 적용할 수 있다!
+
+```ts
+import { ClassSerializerInterceptor, Module } from '@nestjs/common';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [TypeOrmModule.forRoot()],
+  controllers: [AppController],
+  providers: [
+    AppService,
+    {
+      provide: APP_INTERCEPTOR,
+      useClass: ClassSerializerInterceptor,
+    },
+  ],
+})
+```
+
+이렇게 말이다! 넘나 좋은것!!!
+
+`@Exclude`는 클래스 단위에도 적용시킬 수 있다.
+
+그리고 `class transformer`의 좋은 점은 하나 더 있다. 값이 들어오면, 그것을 다른 값으로 변환시켜줄 수 있다는 것이다. 예를 들어, `@Transform` 데코레이터를 이용하면, 값을 변환시켜줄 수 있다.
+
+```ts
+  @Transform(({ value }) => value + '!!!')
+  @IsString()
+  @IsOptional()
+  title?: string;
+```
+
+## pagination 기본기 - Cursor Pagination
+
+커서 페이지네이션을 만들기 위해서, 우선 `paginatePostDto`를 만들어주자
+
+```ts
+export class PaginatePostDto {
+  @IsNumber()
+  @IsOptional()
+  where__id_more_than?: number;
+
+  @IsNumber()
+  @IsOptional()
+  where__id_less_than?: number;
+
+  @IsIn(['ASC', 'DESC'])
+  @IsOptional()
+  order__createdAt: 'ASC' | 'DESC' = 'ASC';
+
+  @IsNumber()
+  @IsOptional()
+  take: number = 20;
+}
+```
+
+각각의 프로퍼티가 무엇을 의미하는 지는 알 것이다. 그리고 이것을 기반으로 페이징을 구현할 것이다. 그리고, `order__createdAt`처럼 클래스 프로퍼티의 기본 값을 허락하려면, 다음과 같이 설정해줘야 한다. `class validator`를 따라 자동 형 변환이 되게 부가적인 옵션도 넣주도록 하자.
+
+```ts
+app.useGlobalPipes(
+  new ValidationPipe({
+    transform: true,
+    transformOptions: {
+      enableImplicitConversion: true,
+    },
+  }),
+);
+```
+
+이렇게 `main.ts`파일에서 설정해주자.
+
+그리고 서비스 폴더에 다음과 같이 `pagenatePosts`를 만들어보자.
+
+```ts
+  async pagenatePosts(paginatePostDto: PaginatePostDto) {
+    const { where__id_more_than, where__id_less_than, order__createdAt, take } =
+      paginatePostDto;
+
+    if (where__id_more_than && where__id_less_than) {
+      throw new Error(
+        'where__id_more_than and where__id_less_than cannot be used at the same time',
+      );
+    }
+
+    const getId = () => {
+      if (where__id_more_than) return MoreThan(where__id_more_than);
+      else if (where__id_less_than) return LessThan(where__id_less_than);
+      else {
+        if (order__createdAt == 'ASC') return MoreThan(0);
+        else return LessThan(Infinity);
+      }
+    };
+
+    const posts = await this.postsRepository.find({
+      where: {
+        id: getId(),
+      },
+      order: {
+        createdAt: order__createdAt,
+      },
+      take,
+    });
+
+    const lastItem = posts.length > 0 ? posts[posts.length - 1] : null;
+    const nextUrl = lastItem ? new URL('http://localhost:3000/posts') : null;
+    if (nextUrl) {
+      for (const key of Object.keys(paginatePostDto)) {
+        if (!paginatePostDto[key]) continue;
+
+        if (key != 'where__id_more_than' && key != 'where__id_less_than') {
+          nextUrl.searchParams.append(key, paginatePostDto[key]);
+        }
+      }
+
+      if (paginatePostDto.order__createdAt == 'ASC') {
+        nextUrl.searchParams.append(
+          'where__id_more_than',
+          lastItem.id.toString(),
+        );
+      } else {
+        nextUrl.searchParams.append(
+          'where__id_less_than',
+          lastItem.id.toString(),
+        );
+      }
+    }
+
+    return {
+      data: posts,
+      cursor: {
+        after: lastItem?.id,
+      },
+      count: posts?.length,
+      next: nextUrl?.toString(),
+    };
+  }
+```
+
+가장 간단한 형태의 커서 `paginate` 함수이다! 이것을 컨트롤러에서 적용하면 내가 원하는 페이지네이션 탄생이다.


### PR DESCRIPTION
## Pipe

파이프는 `PipeTransform` 인터페이스를 구현하는 `@Injectable()` 데코레이터로 주석이 달린 클래스입니다.
![Alt text](https://docs.nestjs.com/assets/Pipe_1.png)

파이프에는 두 가지 일반적인 사용 사례가 있습니다.

**변환**: 입력 데이터를 원하는 형식으로 변환합니다(예: 문자열에서 정수로).
**유효성 검사**: 입력 데이터를 평가하고 유효한 경우 변경하지 않고 그대로 전달합니다. 그렇지 않으면 예외를 발생시킵니다.

### Built-in pipes

Nest에는 기본적으로 사용 가능한 9개의 파이프가 함께 제공됩니다.

- `ValidationPipe`
- `ParseIntPipe`
- `ParseFloatPipe`
- `ParseBoolPipe`
- `ParseArrayPipe`
- `ParseUUIDPipe`
- `ParseEnumPipe`
- `DefaultValuePipe`
- `ParseFilePipe`

They're exported from the @nestjs/common package.

어떻게 쓰는지 예제를 보자.

```ts
@Get(':id')
getPost(@Param('id', ParseIntPipe) id: number) {
  return this.postsService.findOne(id);
}
```

이렇게, 파이프라인을 형성해서 값을 정수형으로 바꿔줄 수 있다.

만약 정수형 문자열이 오지 않는다면, 예외를 발생시키고 그것을 클라이언트 측에 보내준다.

```json
{
  "statusCode": 400,
  "message": "Validation failed (numeric string is expected)",
  "error": "Bad Request"
}
```

이렇게 말이다. 물론, 내가 어떤 예외를 던질 지도 커스터마이징 해줄 수 있다.

```ts
@Get(':id')
getPost(@Param('id', ParseIntPipe({errorHttpStatusCode: HttpStatus.NOT_ACCEPTABLE})) id: number) {
  return this.postsService.findOne(id);
}
```

이렇게 파이프 안에 옵션을 넣어주면 된다.

`@ValidationPipe`의 예제도 한번 보자.

```ts
@Post()
@UsePipes(ValidationPipe)
create(@Body() createCatDto: CreateCatDto) {
  this.catsService.create(createCatDto);
}
```

### 커스텀 파이프

그리고 커스텀 파이프도 만들 수 있다.

예시를 보자.

```ts
@Injectable()
class PasswordPipe implements PipeTransform {
  transform(value: any, metadata: ArgumentMetadata) {
    if (value.toString().length > 8) {
      return new BadRequestException('Password is too long');
    }

    return value.toString();
  }
}
```

### DefalutValuePipe

`DefaultValuePipe`는 파이프를 사용하지 않을 때 기본값을 설정할 수 있게 해준다.

```ts
@Get()
findAll(@Query('page', new DefaultValuePipe(value)) page: number) {
  return `This action returns all cats (limit: ${page} items)`;
}
```

default 값은 `value`에 있는 값이 된다.

### 여러개의 파이프 동시에 적용하기

여러개의 파이프를 동시에 적용할 수 있다.

```ts
@Post()
@UsePipes(new ValidationPipe(), new PasswordPipe())
create(@Body() createUserDto: CreateUserDto) {
  this.usersService.create(createUserDto);
}
```

## 상속을 이용한 BaseModel Entity 만들기

```ts
import {
  PrimaryGeneratedColumn,
  CreateDateColumn,
  UpdateDateColumn,
} from 'typeorm';

export class BaseModel {
  @PrimaryGeneratedColumn()
  id: number;

  @CreateDateColumn()
  createdAt: Date;

  @UpdateDateColumn()
  updatedAt: Date;
}
```

이렇게 하면, 모든 엔티티가 이 엔티티를 상속받아서 사용할 수 있다.

## pgAdmin 사용하기

pgAdmin을 사용하면, 데이터베이스를 시각적으로 관리할 수 있다. 무료라서 좋당.
다른 툴과 비슷하게, 연결하고 사용하면 된당

## Guard 이론 및 구현할 스팩 정리

`Guard`는 `@Injectable()` 데코레이터로 주석이 달린 클래스입니다. `CanActivate` 인터페이스를 구현해야합니다. `CanActivate` 인터페이스는 `ExecutionContext` 인스턴스를 사용하여 요청을 검사합니다. `ExecutionContext`에는 `switchToHttp()` 메서드가 있습니다. 이 메서드는 `getRequest()` 및 `getResponse()` 메서드를 사용하여 요청 및 응답 객체에 액세스 할 수있는 `HttpArgumentsHost` 인스턴스를 반환합니다.

`auth/guard/basic-token.guard.ts`를 만들어서 가드를 써보자. `pipe`를 만드는 것과 매우 유사하니, 겁먹지 말자.

```ts
import {
  CanActivate,
  Injectable,
  ExecutionContext,
  UnauthorizedException,
} from '@nestjs/common';
import { AuthService } from '../auth.service';

@Injectable()
export class BasicTokenGuard implements CanActivate {
  constructor(private readonly authService: AuthService) {}

  async canActivate(context: ExecutionContext): Promise<boolean> {
    const req = context.switchToHttp().getRequest();
    const rawToken = req.headers.Authorization;

    if (rawToken) {
      throw new UnauthorizedException('No token provided');
    }

    const token = this.authService.extractTokenFromHeader(rawToken, false);
    const { email, password } = this.authService.decodeBasicToken(token);

    const user = await this.authService.authenticateWithEmailAndPassword({
      email,
      password,
    });

    req.user = user;

    return true;
  }
}
```

이렇게 만들었는데, 로직은 크게 어렵지 않으니 이해하리라 믿는다. 이렇게 가드를 작성하고

```ts
  @Post('login/email')
  @UseGuards(BasicTokenGuard)
  loginEmail(@Headers('Authorization') authorization: string, @Request() req) {
    const email = req.user.email;
    const password = req.user.password;
    return this.authService.loginWithEmail({ email, password });
  }
```

이렇게 써주면, 요청이 들어오면 저 위에 있는 가드 코드를 한번 통과하고, 만약 실패하면 에러를 던지겠지? 성공하면 req.user = user가 되어서, 이제 request에서 user 정보를 가져올 수 있게 된다. 참 간단하다. express와 닮은 게 있는 것 같다.

`BasicTokenGuard`를 만들었으니, `BearerTokenGuard`도 만들어보자.

```ts
import {
  CanActivate,
  Injectable,
  ExecutionContext,
  UnauthorizedException,
} from '@nestjs/common';
import { AuthService } from '../auth.service';
import { UsersService } from 'src/users/users.service';

@Injectable()
class BearerTokenGuard implements CanActivate {
  constructor(
    private readonly authService: AuthService,
    private readonly usersService: UsersService,
  ) {}

  async canActivate(context: ExecutionContext): Promise<boolean> {
    const req = context.switchToHttp().getRequest();
    const rawToken = req.headers.authorization;

    if (rawToken) {
      throw new UnauthorizedException('No token provided');
    }

    const token = this.authService.extractTokenFromHeader(rawToken, true);
    const decode = await this.authService.verifyToken(token);
    const user = await this.usersService.getUserByEmail(decode.email);

    req.token = token;
    req.tokenType = decode.type;
    req.user = user;

    return true;
  }
}

@Injectable()
export class AccessTokenGuard extends BearerTokenGuard {
  async canActivate(context: ExecutionContext): Promise<boolean> {
    await super.canActivate(context);

    const req = context.switchToHttp().getRequest();

    if (req.tokenType !== 'access') {
      throw new UnauthorizedException('this is not access token');
    }

    return true;
  }
}

@Injectable()
export class RefreshTokenGuard extends BearerTokenGuard {
  async canActivate(context: ExecutionContext): Promise<boolean> {
    await super.canActivate(context);

    const req = context.switchToHttp().getRequest();

    if (req.tokenType !== 'refresh') {
      throw new UnauthorizedException('this is not refresh token');
    }

    return true;
  }
}
```

위와 같이 만들었다. 로직은 크게 어렵지 않다. 잘 읽고 따라가보자. 이렇게 만든 것들을 이용해서, 컨트롤러를 다음과 같이 수정해줬다.

```ts
  @Post('token/access')
  @UseGuards(RefreshTokenGuard)
  getAccessToken(@Request() req) {
    const newToken = this.authService.rotateToken(req.token, false);

    return {
      accessToken: newToken,
    };
  }

  @Post('token/refresh')
  @UseGuards(RefreshTokenGuard)
  getRefreshToken(@Request() req) {
    const newToken = this.authService.rotateToken(req.token, true);

    return {
      refreshToken: newToken,
    };
  }
```

정말 깔끔해졌다! 이제, 별 다른 절차 없이 가드만을 이용해서 토큰 재발급 여부를 수락하거나 거절할 수 있게 되었다. 그리고, req에 더 많은 정보를 포함하게 하여 요청 처리에 훨씬 편하게 되었다. `RefeshTokenGuard`로 토큰을 재발급 해주는 부분을 완성했으니, `AccessTokenGuard`를 이용하여 권한이 있는 사람만 접근할 수 있는 곳을 설정해주자.

`posts controller` 중 하나의 엔드포인트를 다음과 같이 수정하였다.

```ts
  @Post('/create')
  @UseGuards(AccessTokenGuard)
  create(@Request() req, @Body() createPostDto: CreatePostDto) {
    return this.postsService.create(createPostDto, req.user.id);
  }
```

짠! 이제 AccessToken을 발급받아야만 글을 작성할 수 있게 되었다!

## 커스텀 데코레이터

이제 `AccessTokenGuard`로 접근을 제한할 수 있지만, user 정보를 가져오고 싶을 때 매번 req 객체에서 req.user를 참조해서 하기 귀찮을 수 있다. 이것을 그냥 컨트롤러 매개변수로 받을 수는 없을까??라고 생각한 당신을 위해 커스텀 데코레티어가 있다. 이것을 이용하면 쉽게 할 수 있다고 한다.

```ts
import {
  ExecutionContext,
  InternalServerErrorException,
  createParamDecorator,
} from '@nestjs/common';

export const User = createParamDecorator(
  (data: string, context: ExecutionContext) => {
    const req = context.switchToHttp().getRequest();

    if (!req.user) {
      throw new InternalServerErrorException('there is no user on the request');
    }

    switch (data) {
      case 'id':
        return req.user.id;
      case 'email':
        return req.user.email;
      case 'password':
        return req.user.password;
      default:
        return req.user;
    }
  },
);
```

이렇게 간단하게 데코레이터를 작성할 수 있다. 이것을 적용시켜서 반복되는 부분을 줄여보자!

```ts
  @Post('/create')
  @UseGuards(AccessTokenGuard)
  create(@User('id') id, @Body() createPostDto: CreatePostDto) {
    return this.postsService.create(createPostDto, id);
  }
```

짠! 요렇게 간단하게 사용할 수 있다는것!

## Postman 기능 심화

## class validator

class validator는 `class-validator` 패키지를 이용해서 사용할 수 있다. 이것을 이용하면, DTO에 대한 유효성 검사를 쉽게 할 수 있다.

```bash
npm i class-validator class-transformer
```

```ts
import { IsString } from 'class-validator';

export class CreatePostDto {
  @IsString({ message: 'Content must be a string' })
  content: string;

  @IsString({ message: 'Title must be a string' })
  title: string;
}
```

이렇게 create-post dto에 적용시킬 수 있따. 주의해야할 점은 class-validator를 사용하려면 main.ts에서 다음을 추가해줘야 한다.

```ts
import { ValidationPipe } from '@nestjs/common';
import { NestFactory } from '@nestjs/core';
import { AppModule } from './app.module';

async function bootstrap() {
  const app = await NestFactory.create(AppModule);
  app.useGlobalPipes(new ValidationPipe());
  await app.listen(3000);
}
```

ok? good

그리고, DTO를 만들 때 PickType을 이용하면 굉장히 편리한데, 이것을 이용해서 DTO를 만들어보자.

```ts
import { PickType } from '@nestjs/swagger';

export class CreatePostDto extends PickType(Post, ['title', 'content']) {}
```

이렇게 말이다. class validator는 그러면 entity 파일 해당하는 곳에 넣어주면 되겠지? ㅎㅎ

`@IsOptional` 데코레이터를 이용하면, 필수가 아닌 값에 대해서도 유효성 검사를 할 수 있다.

```ts
import { PartialType } from '@nestjs/mapped-types';
import { CreatePostDto } from './create-post.dto';
import { IsOptional, IsString } from 'class-validator';

export class UpdatePostDto extends PartialType(CreatePostDto) {
  @IsString()
  @IsOptional()
  title?: string;

  @IsString()
  @IsOptional()
  content?: string;
}
```

이렇게 update dto에 대해서 한번 적용시켜 봤다. 유용하게 쓰이겠군.
그리고, `PartialType`은 `@nestjs/mapped-types` 패키지에서 제공하는 것이다. 이것을 이용하면, 기존의 타입을 상속받아서, 모든 필드를 선택적으로 만들어준다. 이것을 이용하면, DTO를 만들 때, 필드를 하나하나 다 적어줄 필요가 없어진다. 이것도 굉장히 유용하게 쓰일 것 같다.

다른 `validator`도 많으니 사용해보자.
`@IsEmail()`, `@Length()`도 사용해봤는데, 똑같으니깐 쓰진 않겠다.

또, `validation messgae`를 일반화 할 수 있다. 언제 이걸 다 넣지 생각한 당신을 위한 것이다.

```ts
@Length(1, 20, {
  message(args: ValidationArguments) {
    if(args.contrains.length == 1){
      return `${args.property} must be longer than ${args.constraints[0]} characters`
    } else {
      return `${args.property} must be longer than ${args.constraints[0]} and shorter than ${args.constraints[1]} characters`
    }
  },
})
title: string;
```

`ValidationArguments`의 매개변수
1: value(입력한 값)
2: constraints(제약 조건) ex) @Length(1, 20) 이면, [1, 20]이 들어온다.
3: target(검증하는 class의 이름)
4: object(검증하고 있는 객체)
5: property(검증하고 있는 프로퍼티 이름)

그래서 이걸 어떻게 일반화해??

`common` 폴더에 `validation-message`라는 폴더를 만들고, 그 안에 `length-validation-message.ts`를 만들어서 다음과 같이 작성해준다.

```ts
import { ValidationArguments } from 'class-validator';

export const lengthValidationMessage = (args: ValidationArguments) => {
  if (args.constraints.length == 1) {
    return `${args.property} must be longer than ${args.constraints[0]} characters`;
  } else {
    return `${args.property} must be longer than ${args.constraints[0]} and shorter than ${args.constraints[1]} characters`;
  }
};
```

자, 이제 만든 이 함수를 저기다가 넣어주면 된당!

```ts
@Length(1, 20, {
  message: lengthValidationMessage,
})
title: string;
```

개꿀! `emailValidationMessage`, `stringValidationMessage`를 또 작성해주고, 다른 모든 entity의 validator message에 적용시켜 줬다!

## class transformer

`class transformer`는 만약 데이터를 조회할 때 특정 필드를 제외하고 싶다면 어떻게 해야할까? 이것을 이용하면 쉽게 할 수 있다.

```ts
  @Exclude()
  password: string;
```

이렇게, 조인연산하여 가져올 때 `@Exclude()` 어노테이션을 적용하고, 엔드포인트에서 `password`를 가져오는 컨트롤러에
`@UseInterceptors(ClassSerializerInterceptor)`를 적용시켜주면 된다.

```ts
  @Get('/me')
  @UseGuards(AccessTokenGuard)
  @UseInterceptors(ClassSerializerInterceptor)
  getMe(@User() user: User) {
    return user;
  }
```

이렇게 말이다! 그러면, User 정보를 가져올 때 `password`는 제외하고 가져온다.
이렇듯, 우리가 데이터를 `직렬화` or `역직렬화`할 때, `class transformer`를 사용하면, 특정 필드를 제외하거나, 특정 필드를 추가할 수 있다.

`@Exclude()`의 옵션으로는 다음이 있다.

- `toPlainOnly`: plainToClass()를 사용할 때 제외할 필드를 지정합니다.(직렬화)
- `toClassOnly`: classToPlain()를 사용할 때 제외할 필드를 지정합니다.(역직렬화)

`@Expose()`의 옵션으로는 다음이 있다.

- `toPlainOnly`: plainToClass()를 사용할 때 노출할 필드를 지정합니다.(직렬화)
- `toClassOnly`: classToPlain()를 사용할 때 노출할 필드를 지정합니다.(역직렬화)

근데, 엔드포인트별로 다 넣을라그러면, 너무 힘들지 않을까? 라고 생각한 당신을 위해 글로벌하게 이 트렌스포머를 적용할 수 있다!

```ts
import { ClassSerializerInterceptor, Module } from '@nestjs/common';
import { APP_INTERCEPTOR } from '@nestjs/core';
import { TypeOrmModule } from '@nestjs/typeorm';
import { AppController } from './app.controller';
import { AppService } from './app.service';

@Module({
  imports: [TypeOrmModule.forRoot()],
  controllers: [AppController],
  providers: [
    AppService,
    {
      provide: APP_INTERCEPTOR,
      useClass: ClassSerializerInterceptor,
    },
  ],
})
```

이렇게 말이다! 넘나 좋은것!!!

`@Exclude`는 클래스 단위에도 적용시킬 수 있다.

그리고 `class transformer`의 좋은 점은 하나 더 있다. 값이 들어오면, 그것을 다른 값으로 변환시켜줄 수 있다는 것이다. 예를 들어, `@Transform` 데코레이터를 이용하면, 값을 변환시켜줄 수 있다.

```ts
  @Transform(({ value }) => value + '!!!')
  @IsString()
  @IsOptional()
  title?: string;
```

## pagination 기본기 - Cursor Pagination

커서 페이지네이션을 만들기 위해서, 우선 `paginatePostDto`를 만들어주자

```ts
export class PaginatePostDto {
  @IsNumber()
  @IsOptional()
  where__id_more_than?: number;

  @IsNumber()
  @IsOptional()
  where__id_less_than?: number;

  @IsIn(['ASC', 'DESC'])
  @IsOptional()
  order__createdAt: 'ASC' | 'DESC' = 'ASC';

  @IsNumber()
  @IsOptional()
  take: number = 20;
}
```

각각의 프로퍼티가 무엇을 의미하는 지는 알 것이다. 그리고 이것을 기반으로 페이징을 구현할 것이다. 그리고, `order__createdAt`처럼 클래스 프로퍼티의 기본 값을 허락하려면, 다음과 같이 설정해줘야 한다. `class validator`를 따라 자동 형 변환이 되게 부가적인 옵션도 넣주도록 하자.

```ts
app.useGlobalPipes(
  new ValidationPipe({
    transform: true,
    transformOptions: {
      enableImplicitConversion: true,
    },
  }),
);
```

이렇게 `main.ts`파일에서 설정해주자.

그리고 서비스 폴더에 다음과 같이 `pagenatePosts`를 만들어보자.

```ts
  async pagenatePosts(paginatePostDto: PaginatePostDto) {
    const { where__id_more_than, where__id_less_than, order__createdAt, take } =
      paginatePostDto;

    if (where__id_more_than && where__id_less_than) {
      throw new Error(
        'where__id_more_than and where__id_less_than cannot be used at the same time',
      );
    }

    const getId = () => {
      if (where__id_more_than) return MoreThan(where__id_more_than);
      else if (where__id_less_than) return LessThan(where__id_less_than);
      else {
        if (order__createdAt == 'ASC') return MoreThan(0);
        else return LessThan(Infinity);
      }
    };

    const posts = await this.postsRepository.find({
      where: {
        id: getId(),
      },
      order: {
        createdAt: order__createdAt,
      },
      take,
    });

    const lastItem = posts.length > 0 ? posts[posts.length - 1] : null;
    const nextUrl = lastItem ? new URL('http://localhost:3000/posts') : null;
    if (nextUrl) {
      for (const key of Object.keys(paginatePostDto)) {
        if (!paginatePostDto[key]) continue;

        if (key != 'where__id_more_than' && key != 'where__id_less_than') {
          nextUrl.searchParams.append(key, paginatePostDto[key]);
        }
      }

      if (paginatePostDto.order__createdAt == 'ASC') {
        nextUrl.searchParams.append(
          'where__id_more_than',
          lastItem.id.toString(),
        );
      } else {
        nextUrl.searchParams.append(
          'where__id_less_than',
          lastItem.id.toString(),
        );
      }
    }

    return {
      data: posts,
      cursor: {
        after: lastItem?.id,
      },
      count: posts?.length,
      next: nextUrl?.toString(),
    };
  }
```

가장 간단한 형태의 커서 `paginate` 함수이다! 이것을 컨트롤러에서 적용하면 내가 원하는 페이지네이션 탄생이다.
