### PR TITLE
[Docs] 학습 내용 정리

### DIFF
--- a/study/2023-11-04.md
+++ b/study/2023-11-04.md
@@ -1,0 +1,169 @@
+## config 모듈 사용하기
+
+설정 파일을 통해서, 서버의 설정 값을 관리하자.
+
+### config 모듈 설치하기
+
+```bash
+$ npm i @nestjs/config
+```
+
+그리고, 프로젝트 디렉터리에 `.env`파일을 만들어주고, 거기에 환경변수를 넣어주면 된다.
+
+```bash
+PORT=3000
+```
+
+요렇게 말이다! 사용하기 위해서는
+
+`app.module.ts`에 `ConfigModule`을 import 해주면 된다.
+
+```ts
+import { ConfigModule } from '@nestjs/config';
+
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: '.env',
+    }),
+  ],
+})
+```
+
+그리고, 원하는 서비스에서 `ConfigService`를 import 해주면 된다.
+
+```ts
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class AppService {
+  constructor(private configService: ConfigService) {}
+
+  getHello(): string {
+    return `Hello World! ${this.configService.get('PORT')}`;
+  }
+}
+```
+
+요렇게 주입하고, 사용할 때는
+`configService.get('KEY')`를 사용하면 된다. 참 쉽다.
+
+근데, 매번 `KEY`를 입력하는 것은 오타가 날 수 있고 귀찮다. 따라서, const.ts 파일을 만들어서, 거기에 `KEY`를 저장해두고, 사용하면 된다.
+
+```ts
+export const CONFIG_OPTIONS = 'CONFIG_OPTIONS';
+```
+
+이런식으로 말이다!
+
+서비스를 이용해서 받을 수도 있지만, 환경 변수를 이용해서 받을 수도 있다.
+
+```ts
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      envFilePath: process.env.NODE_ENV === 'dev' ? '.env.dev' : '.env.test',
+    }),
+  ],
+})
+```
+
+이렇게 서비스를 주입받을 수 없는 곳에서는 환경 변수로 받아서 사용하면 된다.
+
+## Multer 세팅하기
+
+`multer`는 파일을 업로드할 때 사용하는 미들웨어이다.
+
+```bash
+$ npm i multer @types/multer uuid @types/uuid
+```
+
+이렇게 설치하고, `app.module.ts`에 `MulterModule`을 import 해주면 된다.
+
+```ts
+import { MulterModule } from '@nestjs/platform-express';
+
+@Module({
+  imports: [
+    MulterModule.register({
+      limits: {
+        fileSize: 1024 * 1024,
+      },
+      fileFilter: (req, file, cb) => {
+        if (file.mimetype !== 'image/png') {
+          cb(new HttpException('Wrong file type', HttpStatus.BAD_REQUEST), false);
+        }
+        cb(null, true);
+      },
+      storage: {
+        destination: (req, file, cb) => {
+          cb(null, './uploads');
+        },
+        filename: (req, file, cb) => {
+          const randomName = uuidv4();
+          const extension = path.extname(file.originalname);
+          cb(null, `${randomName}${extension}`);
+        },
+      },
+      }
+    }),
+  ],
+})
+```
+
+`limits`는 파일의 사이즈를 제한하는 것이다. `fileFilter`는 파일의 필터를 설정하는 것이다. `storage`는 파일을 저장하는 방식을 설정하는 것이다. `destination`은 파일을 저장할 경로를 설정하는 것이다. `filename`은 파일의 이름을 설정하는 것이다.
+
+그리고, `app.controller.ts`에서 `@UseInterceptors`를 사용해서, `FileInterceptor`를 사용하면 된다.
+
+```ts
+import { FileInterceptor } from '@nestjs/platform-express';
+
+@Controller('app')
+export class AppController {
+  @Post('/upload')
+  @UseInterceptors(FileInterceptor('file'))
+  uploadFile(@UploadedFile() file) {
+    console.log(file);
+  }
+}
+```
+
+이제, 파일을 업로드하면 `uploads` 폴더에 저장이 된다. 주의해야 할 점은, `multipart/form-data`로 보내야 한다는 것이다.
+
+여기까지 했으면 의문이 들 것이다. 파일을 보내면 저장되는 것 까지는 알겠다. 하지만, 그것을 어떻게 다시 클라이언트로 보내준단 말인가? 그래서, `static`을 사용하면 된다.
+
+```bash
+npm i @nestjs/serve-static
+```
+
+설치해 주고, `AppModule`에 `ServeStaticModule`을 import 해주면 된다.
+
+```ts
+import { ServeStaticModule } from '@nestjs/serve-static';
+
+@Module({
+  imports: [
+    ServeStaticModule.forRoot({
+      rootPath: join(__dirname, '..', 'uploads'),
+      serveRoot: '/uploads',
+    }),
+  ],
+})
+```
+
+`rootPath`는 파일이 저장되는 경로를 설정하는 것이다. `serveRoot`는 클라이언트에서 접근할 수 있는 경로를 설정하는 것이다. 이렇게 설정하면, `http://localhost:3000/uploads/파일이름`으로 접근할 수 있다.
+
+자 이제 클라이언트에서 파일을 업로드하고, 자신이 올린 파일을 확인할 수도 있다. 마지막으로 해줘야할 것은 무엇인지 알겠는가? 바로 `post`를 클라이언트로 보내줄 때, 지금은 파일의 이름만 보내주지만, 이것을 `class transformer`를 통해 파일의 전체 `url`로 바꿔주면 된다.
+패키지는 이미 설치했으니, 바로 들어가보자.
+
+```ts
+  @Column({ nullable: true })
+  @Transform(({ value }) => `http://localhost:3000/uploads/${value}`)
+  image?: string;
+```
+
+이렇게 추가해주면 이제 `post`를 요청할 때, `image`의 값이 `http://localhost:3000/uploads/파일이름`으로 바뀌어서 보내진다.
+
+하지만 이 방법은 굉장히 전통적인 방법이라고 한다. 다음 시간에 더 현대적인 방법을 배우도록 하자.


### PR DESCRIPTION
## config 모듈 사용하기

설정 파일을 통해서, 서버의 설정 값을 관리하자.

### config 모듈 설치하기

```bash
$ npm i @nestjs/config
```

그리고, 프로젝트 디렉터리에 `.env`파일을 만들어주고, 거기에 환경변수를 넣어주면 된다.

```bash
PORT=3000
```

요렇게 말이다! 사용하기 위해서는

`app.module.ts`에 `ConfigModule`을 import 해주면 된다.

```ts
import { ConfigModule } from '@nestjs/config';

@Module({
  imports: [
    ConfigModule.forRoot({
      isGlobal: true,
      envFilePath: '.env',
    }),
  ],
})
```

그리고, 원하는 서비스에서 `ConfigService`를 import 해주면 된다.

```ts
import { ConfigService } from '@nestjs/config';

@Injectable()
export class AppService {
  constructor(private configService: ConfigService) {}

  getHello(): string {
    return `Hello World! ${this.configService.get('PORT')}`;
  }
}
```

요렇게 주입하고, 사용할 때는
`configService.get('KEY')`를 사용하면 된다. 참 쉽다.

근데, 매번 `KEY`를 입력하는 것은 오타가 날 수 있고 귀찮다. 따라서, const.ts 파일을 만들어서, 거기에 `KEY`를 저장해두고, 사용하면 된다.

```ts
export const CONFIG_OPTIONS = 'CONFIG_OPTIONS';
```

이런식으로 말이다!

서비스를 이용해서 받을 수도 있지만, 환경 변수를 이용해서 받을 수도 있다.

```ts
@Module({
  imports: [
    ConfigModule.forRoot({
      isGlobal: true,
      envFilePath: process.env.NODE_ENV === 'dev' ? '.env.dev' : '.env.test',
    }),
  ],
})
```

이렇게 서비스를 주입받을 수 없는 곳에서는 환경 변수로 받아서 사용하면 된다.

## Multer 세팅하기

`multer`는 파일을 업로드할 때 사용하는 미들웨어이다.

```bash
$ npm i multer @types/multer uuid @types/uuid
```

이렇게 설치하고, `app.module.ts`에 `MulterModule`을 import 해주면 된다.

```ts
import { MulterModule } from '@nestjs/platform-express';

@Module({
  imports: [
    MulterModule.register({
      limits: {
        fileSize: 1024 * 1024,
      },
      fileFilter: (req, file, cb) => {
        if (file.mimetype !== 'image/png') {
          cb(new HttpException('Wrong file type', HttpStatus.BAD_REQUEST), false);
        }
        cb(null, true);
      },
      storage: {
        destination: (req, file, cb) => {
          cb(null, './uploads');
        },
        filename: (req, file, cb) => {
          const randomName = uuidv4();
          const extension = path.extname(file.originalname);
          cb(null, `${randomName}${extension}`);
        },
      },
      }
    }),
  ],
})
```

`limits`는 파일의 사이즈를 제한하는 것이다. `fileFilter`는 파일의 필터를 설정하는 것이다. `storage`는 파일을 저장하는 방식을 설정하는 것이다. `destination`은 파일을 저장할 경로를 설정하는 것이다. `filename`은 파일의 이름을 설정하는 것이다.

그리고, `app.controller.ts`에서 `@UseInterceptors`를 사용해서, `FileInterceptor`를 사용하면 된다.

```ts
import { FileInterceptor } from '@nestjs/platform-express';

@Controller('app')
export class AppController {
  @Post('/upload')
  @UseInterceptors(FileInterceptor('file'))
  uploadFile(@UploadedFile() file) {
    console.log(file);
  }
}
```

이제, 파일을 업로드하면 `uploads` 폴더에 저장이 된다. 주의해야 할 점은, `multipart/form-data`로 보내야 한다는 것이다.

여기까지 했으면 의문이 들 것이다. 파일을 보내면 저장되는 것 까지는 알겠다. 하지만, 그것을 어떻게 다시 클라이언트로 보내준단 말인가? 그래서, `static`을 사용하면 된다.

```bash
npm i @nestjs/serve-static
```

설치해 주고, `AppModule`에 `ServeStaticModule`을 import 해주면 된다.

```ts
import { ServeStaticModule } from '@nestjs/serve-static';

@Module({
  imports: [
    ServeStaticModule.forRoot({
      rootPath: join(__dirname, '..', 'uploads'),
      serveRoot: '/uploads',
    }),
  ],
})
```

`rootPath`는 파일이 저장되는 경로를 설정하는 것이다. `serveRoot`는 클라이언트에서 접근할 수 있는 경로를 설정하는 것이다. 이렇게 설정하면, `http://localhost:3000/uploads/파일이름`으로 접근할 수 있다.

자 이제 클라이언트에서 파일을 업로드하고, 자신이 올린 파일을 확인할 수도 있다. 마지막으로 해줘야할 것은 무엇인지 알겠는가? 바로 `post`를 클라이언트로 보내줄 때, 지금은 파일의 이름만 보내주지만, 이것을 `class transformer`를 통해 파일의 전체 `url`로 바꿔주면 된다.
패키지는 이미 설치했으니, 바로 들어가보자.

```ts
  @Column({ nullable: true })
  @Transform(({ value }) => `http://localhost:3000/uploads/${value}`)
  image?: string;
```

이렇게 추가해주면 이제 `post`를 요청할 때, `image`의 값이 `http://localhost:3000/uploads/파일이름`으로 바뀌어서 보내진다.

하지만 이 방법은 굉장히 전통적인 방법이라고 한다. 다음 시간에 더 현대적인 방법을 배우도록 하자.
