### PR TITLE
2023 11 06

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { User } from './users/entities/user.entity';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { ServeStaticModule } from '@nestjs/serve-static';
+import { Image } from './common/entities/image.entity';
 
 @Module({
   controllers: [AppController],
@@ -38,7 +39,7 @@ import { ServeStaticModule } from '@nestjs/serve-static';
       username: 'postgres',
       password: 'postgres',
       database: 'postgres',
-      entities: [Post, User],
+      entities: [Post, User, Image],
       synchronize: true,
     }),
   ],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,9 +8,6 @@ import { UsersModule } from './users/users.module';
 import { User } from './users/entities/user.entity';
 import { AuthModule } from './auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
-import { MulterModule } from '@nestjs/platform-express';
-import { extname } from 'path';
-import { v4 as uuid } from 'uuid';
 import { ServeStaticModule } from '@nestjs/serve-static';
 
 @Module({
@@ -26,26 +23,6 @@ import { ServeStaticModule } from '@nestjs/serve-static';
     PostsModule,
     UsersModule,
     AuthModule,
-    MulterModule.register({
-      limits: {
-        fileSize: 1024 * 1024 * 5, // 5MB
-      },
-      fileFilter: (req, file, cb) => {
-        if (!file.originalname.match(/\.(jpg|jpeg|png)$/)) {
-          return cb(new Error('Only image files are allowed!'), false);
-        }
-
-        cb(null, true);
-      },
-      storage: {
-        destination: (req, file, cb) => {
-          cb(null, 'uploads');
-        },
-        filename: (req, file, cb) => {
-          cb(null, `${uuid()}${extname(file.originalname)}`);
-        },
-      },
-    }),
     ServeStaticModule.forRoot({
       rootPath: `${__dirname}/../uploads`,
       serveRoot: '/uploads',

--- a/src/common/common.controller.ts
+++ b/src/common/common.controller.ts
@@ -1,0 +1,24 @@
+import {
+  Controller,
+  Post,
+  UseInterceptors,
+  UploadedFile,
+  UseGuards,
+} from '@nestjs/common';
+import { CommonService } from './common.service';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
+
+@Controller('common')
+export class CommonController {
+  constructor(private readonly commonService: CommonService) {}
+
+  @Post('image')
+  @UseInterceptors(FileInterceptor('image'))
+  @UseGuards(AccessTokenGuard)
+  postImage(@UploadedFile() file: Express.Multer.File) {
+    return {
+      fileName: file.filename,
+    };
+  }
+}

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,9 +1,38 @@
 import { Module } from '@nestjs/common';
 import { CommonService } from './common.service';
+import { MulterModule } from '@nestjs/platform-express';
+import { extname } from 'path';
+import { v4 as uuid } from 'uuid';
+import { AuthModule } from 'src/auth/auth.module';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
   controllers: [],
   providers: [CommonService],
   exports: [CommonService],
+  imports: [
+    MulterModule.register({
+      limits: {
+        fileSize: 1024 * 1024 * 5, // 5MB
+      },
+      fileFilter: (req, file, cb) => {
+        if (!file.originalname.match(/\.(jpg|jpeg|png)$/)) {
+          return cb(new Error('Only image files are allowed!'), false);
+        }
+
+        cb(null, true);
+      },
+      storage: {
+        destination: (req, file, cb) => {
+          cb(null, 'uploads/temp');
+        },
+        filename: (req, file, cb) => {
+          cb(null, `${uuid()}${extname(file.originalname)}`);
+        },
+      },
+    }),
+    AuthModule,
+    UsersModule,
+  ],
 })
 export class CommonModule {}

--- a/src/common/const/paths.const.ts
+++ b/src/common/const/paths.const.ts
@@ -1,0 +1,30 @@
+import { join } from 'path';
+
+// 프로젝트가 시작된 위치 (프로젝트 루트)
+export const PROJECT_ROOT_PATH = process.cwd();
+
+// 외부에서 접근 가능한 파일들을 모아둘 폴더
+export const PUBLIC_FOLDER_NAME = 'uploads';
+
+// 포스트 이미지들을 저장할 폴더 이름
+export const POSTS_FOLDER_NAME = 'posts';
+
+// 임시 폴더 이름
+export const TEMP_FOLDER_NAME = 'temp';
+
+// 실제 공개폴더의 전체 위치
+// /{프로젝트 위치}/uploads
+export const PUBLIC_FOLDER_PATH = join(PROJECT_ROOT_PATH, PUBLIC_FOLDER_NAME);
+
+// 실제 임시 파일을 저장할 위치
+// /{프로젝트 위치}/uploads/posts/xxx.jpg
+export const POST_IMAGE_PATH = join(PUBLIC_FOLDER_PATH, POSTS_FOLDER_NAME);
+
+// 임시 파일들을 저장할 폴더
+export const TEMP_FOLDER_PATH = join(PUBLIC_FOLDER_PATH, TEMP_FOLDER_NAME);
+
+// /uploads/posts/ -> GET 요청에서 image 위치 반환할때 사용
+export const POST_PUBLIC_IMAGE_PATH = join(
+  PUBLIC_FOLDER_NAME,
+  POSTS_FOLDER_NAME,
+);

--- a/src/common/entities/image.entity.ts
+++ b/src/common/entities/image.entity.ts
@@ -1,0 +1,37 @@
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { Base } from './base.entity';
+import { IsInt, IsOptional, IsString } from 'class-validator';
+import { Transform } from 'class-transformer';
+import { join } from 'path';
+import { POST_IMAGE_PATH } from '../const/paths.const';
+import { Post } from 'src/posts/entities/post.entity';
+
+export enum ImageType {
+  POST_IMAGE = 'POST_IMAGE',
+  USER_IMAGE = 'USER_IMAGE',
+}
+
+@Entity()
+export class Image extends Base {
+  @Column({ default: 0 })
+  @IsInt()
+  @IsOptional()
+  order: number;
+
+  @Column({ type: 'enum', enum: ImageType, default: ImageType.POST_IMAGE })
+  type: ImageType;
+
+  @Column()
+  @IsString()
+  @Transform(({ value, obj }) => {
+    if (obj.type === ImageType.POST_IMAGE) {
+      return join(POST_IMAGE_PATH, value);
+    } else {
+      return value;
+    }
+  })
+  path: string;
+
+  @ManyToOne(() => Post, (post) => post.images)
+  post?: Post;
+}

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,9 +1,9 @@
 import { PickType } from '@nestjs/mapped-types';
 import { Post } from '../entities/post.entity';
-import { IsOptional, IsString } from 'class-validator';
+import { IsArray, IsOptional, IsString } from 'class-validator';
 
 export class CreatePostDto extends PickType(Post, ['title', 'content']) {
-  @IsString()
+  @IsArray()
   @IsOptional()
-  image?: string;
+  images: string[] = [];
 }

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,4 +1,9 @@
 import { PickType } from '@nestjs/mapped-types';
 import { Post } from '../entities/post.entity';
+import { IsOptional, IsString } from 'class-validator';
 
-export class CreatePostDto extends PickType(Post, ['title', 'content']) {}
+export class CreatePostDto extends PickType(Post, ['title', 'content']) {
+  @IsString()
+  @IsOptional()
+  image?: string;
+}

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -16,7 +16,7 @@ export class Post extends Base {
   title: string;
 
   @Column({ nullable: true })
-  @Transform(({ value }) => `http://localhost:3000/uploads/${value}`)
+  @Transform(({ value }) => `http://localhost:3000/uploads/posts/${value}`)
   image?: string;
 
   @ManyToOne(() => User, (user) => user.posts)

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -1,9 +1,10 @@
 import { Transform } from 'class-transformer';
 import { IsString } from 'class-validator';
 import { Base } from 'src/common/entities/base.entity';
+import { Image } from 'src/common/entities/image.entity';
 import { stringValidationMessage } from 'src/common/validation-message/string-validation.message';
 import { User } from 'src/users/entities/user.entity';
-import { Column, Entity, ManyToOne } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany } from 'typeorm';
 
 @Entity({ name: 'posts' })
 export class Post extends Base {
@@ -15,10 +16,9 @@ export class Post extends Base {
   @IsString({ message: stringValidationMessage })
   title: string;
 
-  @Column({ nullable: true })
-  @Transform(({ value }) => `http://localhost:3000/uploads/posts/${value}`)
-  image?: string;
-
   @ManyToOne(() => User, (user) => user.posts)
   user: User;
+
+  @OneToMany(() => Image, (image) => image.post, { cascade: true })
+  images: Image[];
 }

--- a/src/posts/image/dto/create-image.dto.ts
+++ b/src/posts/image/dto/create-image.dto.ts
@@ -1,0 +1,9 @@
+import { PickType } from '@nestjs/mapped-types';
+import { Image } from 'src/common/entities/image.entity';
+
+export class CreatePostImageDto extends PickType(Image, [
+  'path',
+  'order',
+  'type',
+  'post',
+]) {}

--- a/src/posts/image/images.service.ts
+++ b/src/posts/image/images.service.ts
@@ -1,0 +1,57 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Image } from 'src/common/entities/image.entity';
+import { QueryRunner, Repository } from 'typeorm';
+import { CreatePostImageDto } from './dto/create-image.dto';
+import {
+  POST_IMAGE_PATH,
+  PUBLIC_FOLDER_PATH,
+} from 'src/common/const/paths.const';
+import { promises } from 'fs';
+import { basename, join } from 'path';
+
+@Injectable()
+export class PostImageService {
+  constructor(
+    @InjectRepository(Image)
+    private readonly imagesRepository: Repository<Image>,
+  ) {}
+
+  getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(Image) : this.imagesRepository;
+  }
+
+  async createPostImage(
+    createPostImageDto: CreatePostImageDto,
+    qr?: QueryRunner,
+  ) {
+    const tempFilePath = join(PUBLIC_FOLDER_PATH, createPostImageDto.path);
+
+    try {
+      // 파일이 존재하는지 확인
+      // 만약에 존재하지 않는다면 에러를 던짐
+      await promises.access(tempFilePath);
+    } catch (e) {
+      throw new BadRequestException('파일이 존재하지 않습니다.');
+    }
+
+    // 파일의 이름만 가져오기
+    const fileName = basename(tempFilePath);
+
+    // 새로 이동할 포스트 폴더의 경로 + 이미지 이름
+    const newPath = join(POST_IMAGE_PATH, fileName);
+
+    // save
+    const result = await this.getRepository(qr).save({
+      order: createPostImageDto.order,
+      path: newPath,
+      type: createPostImageDto.type,
+      post: createPostImageDto.post,
+    });
+
+    // 파일 이동
+    await promises.rename(tempFilePath, newPath);
+
+    return true;
+  }
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -10,6 +10,7 @@ import {
   Query,
   UseInterceptors,
   UploadedFile,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
@@ -18,19 +19,51 @@ import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
 import { User } from 'src/users/decorators/user.decorator';
 import { PaginatePostDto } from './dto/paginate-post.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { ImageType } from 'src/common/entities/image.entity';
+import { DataSource } from 'typeorm';
+import { PostImageService } from './image/images.service';
 
 @Controller('posts')
 export class PostsController {
-  constructor(private readonly postsService: PostsService) {}
+  constructor(
+    private readonly postsService: PostsService,
+    private readonly dataSource: DataSource,
+    private readonly postImageService: PostImageService,
+  ) {}
 
   @Post('/create')
   @UseGuards(AccessTokenGuard)
   async create(@User('id') id, @Body() createPostDto: CreatePostDto) {
-    if (createPostDto.image) {
-      await this.postsService.createPostImage(createPostDto);
-    }
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
 
-    return this.postsService.create(createPostDto, id);
+    try {
+      const post = await this.postsService.create(createPostDto, id, qr);
+
+      for (let i = 0; i < createPostDto.images.length; i++) {
+        await this.postImageService.createPostImage(
+          {
+            post,
+            order: i,
+            path: createPostDto.images[i],
+            type: ImageType.POST_IMAGE,
+          },
+          qr,
+        );
+      }
+
+      await qr.commitTransaction();
+      return this.postsService.findOne(post.id);
+    } catch (e) {
+      await qr.rollbackTransaction();
+
+      throw new InternalServerErrorException(
+        '게시글을 생성하는데 실패했습니다.',
+      );
+    } finally {
+      qr.release();
+    }
   }
 
   @Get()

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -24,14 +24,13 @@ export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Post('/create')
-  @UseInterceptors(FileInterceptor('image'))
   @UseGuards(AccessTokenGuard)
-  create(
-    @User('id') id,
-    @Body() createPostDto: CreatePostDto,
-    @UploadedFile() file?: Express.Multer.File,
-  ) {
-    return this.postsService.create(createPostDto, id, file?.filename);
+  async create(@User('id') id, @Body() createPostDto: CreatePostDto) {
+    if (createPostDto.image) {
+      await this.postsService.createPostImage(createPostDto);
+    }
+
+    return this.postsService.create(createPostDto, id);
   }
 
   @Get()

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -6,12 +6,14 @@ import { Post } from './entities/post.entity';
 import { AuthModule } from 'src/auth/auth.module';
 import { UsersModule } from 'src/users/users.module';
 import { CommonModule } from 'src/common/common.module';
+import { Image } from 'src/common/entities/image.entity';
+import { PostImageService } from './image/images.service';
 
 @Module({
   controllers: [PostsController],
-  providers: [PostsService],
+  providers: [PostsService, PostImageService],
   imports: [
-    TypeOrmModule.forFeature([Post]),
+    TypeOrmModule.forFeature([Post, Image]),
     AuthModule,
     UsersModule,
     CommonModule,

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -10,6 +10,12 @@ import { Post } from './entities/post.entity';
 import { LessThan, MoreThan, Repository } from 'typeorm';
 import { PaginatePostDto } from './dto/paginate-post.dto';
 import { CommonService } from 'src/common/common.service';
+import { basename, join } from 'path';
+import {
+  POST_IMAGE_PATH,
+  PUBLIC_FOLDER_PATH,
+} from 'src/common/const/paths.const';
+import { promises } from 'fs';
 
 @Injectable()
 export class PostsService {
@@ -18,17 +24,39 @@ export class PostsService {
     private readonly commonService: CommonService,
   ) {}
 
-  async create(createPostDto: CreatePostDto, userId: number, image?: string) {
+  async create(createPostDto: CreatePostDto, userId: number) {
     const post = this.postsRepository.create({
       user: {
         id: userId,
       },
       content: createPostDto.content,
       title: createPostDto.title,
-      image,
     });
 
     return this.postsRepository.save(post);
+  }
+
+  async createPostImage(createPostDto: CreatePostDto) {
+    const tempFilePath = join(PUBLIC_FOLDER_PATH, createPostDto.image);
+
+    try {
+      // 파일이 존재하는지 확인
+      // 만약에 존재하지 않는다면 에러를 던짐
+      await promises.access(tempFilePath);
+    } catch (e) {
+      throw new BadRequestException('파일이 존재하지 않습니다.');
+    }
+
+    // 파일의 이름만 가져오기
+    const fileName = basename(createPostDto.image);
+
+    // 새로 이동할 포스트 폴더의 경로 + 이미지 이름
+    const newPath = join(POST_IMAGE_PATH, fileName);
+
+    // 파일 이동
+    await promises.rename(tempFilePath, newPath);
+
+    return true;
   }
 
   async findAll() {

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,31 +1,28 @@
-import {
-  BadRequestException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Post } from './entities/post.entity';
-import { LessThan, MoreThan, Repository } from 'typeorm';
+import { QueryRunner, Repository } from 'typeorm';
 import { PaginatePostDto } from './dto/paginate-post.dto';
 import { CommonService } from 'src/common/common.service';
-import { basename, join } from 'path';
-import {
-  POST_IMAGE_PATH,
-  PUBLIC_FOLDER_PATH,
-} from 'src/common/const/paths.const';
-import { promises } from 'fs';
+import { Image } from 'src/common/entities/image.entity';
 
 @Injectable()
 export class PostsService {
   constructor(
     @InjectRepository(Post) private readonly postsRepository: Repository<Post>,
+    @InjectRepository(Image)
+    private readonly imagesRepository: Repository<Image>,
     private readonly commonService: CommonService,
   ) {}
 
-  async create(createPostDto: CreatePostDto, userId: number) {
-    const post = this.postsRepository.create({
+  getRepository(qr?: QueryRunner) {
+    return qr ? qr.manager.getRepository(Post) : this.postsRepository;
+  }
+
+  async create(createPostDto: CreatePostDto, userId: number, qr?: QueryRunner) {
+    const post = this.getRepository(qr).create({
       user: {
         id: userId,
       },
@@ -33,39 +30,24 @@ export class PostsService {
       title: createPostDto.title,
     });
 
-    return this.postsRepository.save(post);
-  }
-
-  async createPostImage(createPostDto: CreatePostDto) {
-    const tempFilePath = join(PUBLIC_FOLDER_PATH, createPostDto.image);
-
-    try {
-      // 파일이 존재하는지 확인
-      // 만약에 존재하지 않는다면 에러를 던짐
-      await promises.access(tempFilePath);
-    } catch (e) {
-      throw new BadRequestException('파일이 존재하지 않습니다.');
-    }
-
-    // 파일의 이름만 가져오기
-    const fileName = basename(createPostDto.image);
-
-    // 새로 이동할 포스트 폴더의 경로 + 이미지 이름
-    const newPath = join(POST_IMAGE_PATH, fileName);
-
-    // 파일 이동
-    await promises.rename(tempFilePath, newPath);
-
-    return true;
+    return this.getRepository(qr).save(post);
   }
 
   async findAll() {
-    return this.postsRepository.find();
+    return this.postsRepository.find({
+      relations: {
+        user: true,
+      },
+    });
   }
 
   async findOne(id: number) {
     const post = await this.postsRepository.findOne({
       where: { id },
+      relations: {
+        user: true,
+        images: true,
+      },
     });
 
     if (!post) {

--- a/study/2023-11-06.md
+++ b/study/2023-11-06.md
@@ -1,0 +1,367 @@
+# 선 업로드 방식
+
+## 이론
+
+앞에서 했던 것처럼 글을 쓸 때 이미지를 업로드하면 이미지의 크기가 크면 사용자는 오래 기다려야 한다. 그래서 이미지를 선 업로드 방식으로 바꾸면, 사용자는 글을 쓸 때 이미지를 업로드하지 않아도 되기 때문에 지연 시간이 많이 줄어든다. 그래서 지금의 방식에서, 파일 선 업로드 방식으로 바꾸면 더 좋다. 따라서 이번 시간에는 파일 선 업로드 방식을 구현해보자.
+
+## 앞으로 변경할 방식
+
+1. 이미지를 선택할 때마다 이미지는 먼저 업로드를 진행
+2. 업로드된 이미지들은 `임시` 폴더에 저장해준다.
+3. 이미지 업로드를 한 후 응답받은 이미지의 경로만 저장해둔 후 포스트를 업로드 할 때 이미지의 경로만 추가해준다.
+4. `POST /posts` 엔드포인트에 이미지 경로를 함께 보낼 경우 해당 이미지를 임시 폴더에서 포스트 폴더로 이동시킨다.
+5. `PostEntity`의 image 필드에 경로를 추가해준다.
+6. S3 presigend url을 사용하면 많이 사용되는 방식이다.
+
+## 이미지 업로드 엔드포인트 생성하기
+
+자, 이제 선 업로드 방식을 위한 업로드 엔드포인트를 생성해보자.
+`common` 모듈에다가 `multer` 모듈을 옮기자. 이제 `common`에서 파일 업로드를 공동으로 처리할 것이기 때문이다.
+
+`app.module`에 있는 `multer` 관련 설정을 `common.module`로 옮겨주었다.
+
+```ts
+import { Module } from '@nestjs/common';
+import { CommonService } from './common.service';
+import { MulterModule } from '@nestjs/platform-express';
+import { extname } from 'path';
+import { v4 as uuid } from 'uuid';
+
+@Module({
+  controllers: [],
+  providers: [CommonService],
+  exports: [CommonService],
+  imports: [
+    MulterModule.register({
+      limits: {
+        fileSize: 1024 * 1024 * 5, // 5MB
+      },
+      fileFilter: (req, file, cb) => {
+        if (!file.originalname.match(/\.(jpg|jpeg|png)$/)) {
+          return cb(new Error('Only image files are allowed!'), false);
+        }
+
+        cb(null, true);
+      },
+      storage: {
+        destination: (req, file, cb) => {
+          cb(null, 'uploads/temp');
+        },
+        filename: (req, file, cb) => {
+          cb(null, `${uuid()}${extname(file.originalname)}`);
+        },
+      },
+    }),
+  ],
+})
+export class CommonModule {}
+```
+
+이제 모든 파일 업로드는, `common`에서 처리할 것이다. 일단 이미지가 업로드되면, `temp` 폴더로 이동시켜줘야 하니, 경로를 수정해주었다.
+
+그 다음, `common.controller`에서, 업로드되는 이미지들을 처리하는 엔드포인트를 구축해주자.
+
+```ts
+import {
+  Controller,
+  Post,
+  UseInterceptors,
+  UploadedFile,
+  UseGuards,
+} from '@nestjs/common';
+import { CommonService } from './common.service';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';
+
+@Controller('common')
+export class CommonController {
+  constructor(private readonly commonService: CommonService) {}
+
+  @Post('image')
+  @UseInterceptors(FileInterceptor('image'))
+  @UseGuards(AccessTokenGuard)
+  postImage(@UploadedFile() file: Express.Multer.File) {
+    return {
+      fileName: file.filename,
+    };
+  }
+}
+```
+
+이제, 파일을 `common/image` 엔드포인트로 업로드하면, `uploads/temp` 폴더로 이동시켜준다. 그리고, 업로드된 파일의 이름을 응답해준다.
+
+## POST posts 엔드포인트 변경하기
+
+common에서 이미지를 받을 것이니, posts 엔드포인트를 변경해주자. 다음과 같이 변경해주었다.
+
+```ts
+  // 컨트롤러
+  @Post('/create')
+  @UseGuards(AccessTokenGuard)
+  create(@User('id') id, @Body() createPostDto: CreatePostDto) {
+    return this.postsService.create(createPostDto, id);
+  }
+
+  // 서비스
+  async create(createPostDto: CreatePostDto, userId: number) {
+    const post = this.postsRepository.create({
+      user: {
+        id: userId,
+      },
+      content: createPostDto.content,
+      title: createPostDto.title,
+    });
+
+    return this.postsRepository.save(post);
+  }
+```
+
+image와 관련된 것들을 모두 제거해주었다. 그리고, 우리는 dto에서 이미지 프로퍼티를 하나 생성해 줄 것이다.
+
+```ts
+export class CreatePostDto extends PickType(Post, ['title', 'content']) {
+  @IsString()
+  @IsOptional()
+  image?: string;
+}
+```
+
+자, 이제 `post`를 실제로 생성하면, `temp`에 있는 이미지를 `posts`로 옮겨주어야 한다. 이것을 구현해보자.
+
+```ts
+  // posts.service
+  async createPostImage(createPostDto: CreatePostDto) {
+    const tempFilePath = join(PUBLIC_FOLDER_PATH, createPostDto.image);
+
+    try {
+      // 파일이 존재하는지 확인
+      // 만약에 존재하지 않는다면 에러를 던짐
+      await promises.access(tempFilePath);
+    } catch (e) {
+      throw new BadRequestException('파일이 존재하지 않습니다.');
+    }
+
+    // 파일의 이름만 가져오기
+    const fileName = basename(createPostDto.image);
+
+    // 새로 이동할 포스트 폴더의 경로 + 이미지 이름
+    const newPath = join(POST_IMAGE_PATH, fileName);
+
+    // 파일 이동
+    await promises.rename(tempFilePath, newPath);
+
+    return true;
+  }
+```
+
+이렇게, temp에 있는 이미지를 posts로 옮기는 함수를 만들어 주었다. 이것을 controller에 적용시켜 보자.
+
+```ts
+  @Post('/create')
+  @UseGuards(AccessTokenGuard)
+  async create(@User('id') id, @Body() createPostDto: CreatePostDto) {
+    if (createPostDto.image) {
+      await this.postsService.createPostImage(createPostDto);
+    }
+
+    return this.postsService.create(createPostDto, id);
+  }
+```
+
+적용시켰다. 이제, 이미지를 업로드하면, 파일의 이름이 리턴되고, 그것으로 dto의 image 프로퍼티를 설정한다. post를 create하면, 비로소, 이미지가 `temp`에서 `posts`로 이동된다. 그리고, post를 생성한다. 선 업로드 방식 구현 완료!
+
+# Transaction
+
+## Transaction 소개
+
+트랜잭션은 데이터베이스의 상태를 변화시키기 위해 수행하는 작업의 단위이다. 트랜잭션은 데이터베이스의 무결성을 보장하기 위해, ACID라는 특성을 만족해야 한다.
+
+start, commit, rollback으로 구성된다.
+
+만약에 post를 생성하고, image를 생성하는데, post는 생성되었는데, image가 생성되지 않았다면, 이것은 데이터베이스의 무결성을 위배하는 것이다. 이것을 방지하기 위해, 트랜잭션을 사용해보자.
+
+## Image Model 만들기
+
+이미지를 지금은 한개만 받을 수 있지만, 이제 여러개 받을 수 있게 만들 것이다. post의 이미지필드를 삭제해주자. 그리고 image entity를 만들고, post와 1:N 관계를 맺어주자.
+
+```ts
+@Entity()
+export class Image extends Base {
+  @Column({ default: 0 })
+  @IsInt()
+  @IsOptional()
+  order: number;
+
+  @Column({ type: 'enum', enum: ImageType, default: ImageType.POST_IMAGE })
+  type: ImageType;
+
+  @Column()
+  @IsString()
+  @Transform(({ value, obj }) => {
+    if (obj.type === ImageType.POST_IMAGE) {
+      return join(POST_IMAGE_PATH, value);
+    } else {
+      return value;
+    }
+  })
+  path: string;
+
+  @ManyToOne(() => Post, (post) => post.images)
+  post?: Post;
+}
+```
+
+```ts
+@Entity({ name: 'posts' })
+export class Post extends Base {
+  ...
+
+  @OneToMany(() => Image, (image) => image.post, { cascade: true })
+  images: Image[];
+}
+```
+
+이렇게 설정해 준 다음, `app.module`에 `entities`를 추가해주자.
+
+```ts
+    ...
+
+    TypeOrmModule.forRoot({
+      type: 'postgres',
+      host: '127.0.0.1',
+      port: 5432,
+      username: 'postgres',
+      password: 'postgres',
+      database: 'postgres',
+      entities: [Post, User, Image],
+      synchronize: true,
+    }),
+
+    ...
+```
+
+그러면 테이블 생성과 연관은 끝난 것이다.
+
+## Image Model 생성하는 로직 작성하기.
+
+이제 만든 Image Model을 가지고, post에서 이미지를 생성하는 부분을 고쳐주자. 우선, `createPostDto`에서, image를 여러개 받을 수 있도록 수정해주자.
+
+```ts
+export class CreatePostDto extends PickType(Post, ['title', 'content']) {
+  @IsArray()
+  @IsOptional()
+  images?: string[] = [];
+}
+```
+
+그 다음, `CreatePostImageDto`를 만들어주자.
+
+```ts
+import { PickType } from '@nestjs/mapped-types';
+import { Image } from 'src/common/entities/image.entity';
+
+export class CreatePostImageDto extends PickType(Image, [
+  'path',
+  'order',
+  'type',
+  'post',
+]) {}
+```
+
+이제 이것을 기반으로, `post`의 단일 이미지 관련 함수들을 수정해줄 것이다. 일단 컨트롤러를 먼저 수정해보자.
+
+```ts
+  @Post('/create')
+  @UseGuards(AccessTokenGuard)
+  async create(@User('id') id, @Body() createPostDto: CreatePostDto) {
+    const post = await this.postsService.create(createPostDto, id);
+
+    for (let i = 0; i < createPostDto.images.length; i++) {
+      await this.postsService.createPostImage({
+        post,
+        order: i,
+        path: createPostDto.images[i],
+        type: ImageType.POST_IMAGE,
+      });
+    }
+
+    return this.postsService.findOne(post.id);
+  }
+```
+
+이렇게 수정해 줬다. 루프를 돌면서, `/uploads/temp`에 생성된 이미지를 기반으로, `Image` 테이블의 row를 생성해 줄 것이다. 서비스 코드를 수정하자.
+
+```ts
+  async createPostImage(createPostImageDto: CreatePostImageDto) {
+    const tempFilePath = join(PUBLIC_FOLDER_PATH, createPostImageDto.path);
+
+    try {
+      // 파일이 존재하는지 확인
+      // 만약에 존재하지 않는다면 에러를 던짐
+      await promises.access(tempFilePath);
+    } catch (e) {
+      throw new BadRequestException('파일이 존재하지 않습니다.');
+    }
+
+    // 파일의 이름만 가져오기
+    const fileName = basename(tempFilePath);
+
+    // 새로 이동할 포스트 폴더의 경로 + 이미지 이름
+    const newPath = join(POST_IMAGE_PATH, fileName);
+
+    // save
+    const result = await this.imagesRepository.save({
+      order: createPostImageDto.order,
+      path: newPath,
+      type: createPostImageDto.type,
+      post: createPostImageDto.post,
+    });
+
+    // 파일 이동
+    await promises.rename(tempFilePath, newPath);
+
+    return true;
+  }
+```
+
+이렇게 수정해 줬다. 이제 이미지를 업로드하면, 해당 이미지가 있는지 확인하고, `Image` 테이블에 만들어진 이미지의 정보로 row를 하나 만들어준다. 그리고, 이미지를 옮겨준다. 이제 `Transaction`을 적용해보자.
+
+## Transaction 시작하기
+
+post를 생성할 때 무언가 에러가 발생하면, 그 어떠한 것도 생성되지 않아야 한다. 그래서 `Transaction`을 사용해보자. `post controller`에서 다음을 주입받자.
+
+```ts
+@Controller('posts')
+export class PostsController {
+  constructor(
+    private readonly postsService: PostsService,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  ...
+}
+```
+
+`dataSource`로 트랜잭션과 관련된 모든 쿼리를 담당할 쿼리 러너를 생성해야 한다. 크게 어렵지 않다 예를 들어보겠다.
+
+```ts
+const qr = this.dataSource.createQueryRunner();
+await qr.connect();
+
+await qr.startTransaction();
+
+try {
+  // 쿼리 실행
+  qr.getRepository(T).save(something);
+
+  ...
+
+  await qr.commitTransaction();
+} catch (e) {
+  await qr.rollbackTransaction();
+} finally {
+  await qr.release();
+}
+```
+
+이렇게, `qr.getRepository`를 써서 쿼리를 날린 다음, 만약 에러가 발생하면 `qr.rollback`을 호출하고, 그렇지 않다면 `qr.commitTransaction`을 호출하면 된다. 그 후 `qr.release`를 호출하면 끝이다. 어렵지 않다!


### PR DESCRIPTION
# 선 업로드 방식

## 이론

앞에서 했던 것처럼 글을 쓸 때 이미지를 업로드하면 이미지의 크기가 크면 사용자는 오래 기다려야 한다. 그래서 이미지를 선 업로드 방식으로 바꾸면, 사용자는 글을 쓸 때 이미지를 업로드하지 않아도 되기 때문에 지연 시간이 많이 줄어든다. 그래서 지금의 방식에서, 파일 선 업로드 방식으로 바꾸면 더 좋다. 따라서 이번 시간에는 파일 선 업로드 방식을 구현해보자.

## 앞으로 변경할 방식

1. 이미지를 선택할 때마다 이미지는 먼저 업로드를 진행
2. 업로드된 이미지들은 `임시` 폴더에 저장해준다.
3. 이미지 업로드를 한 후 응답받은 이미지의 경로만 저장해둔 후 포스트를 업로드 할 때 이미지의 경로만 추가해준다.
4. `POST /posts` 엔드포인트에 이미지 경로를 함께 보낼 경우 해당 이미지를 임시 폴더에서 포스트 폴더로 이동시킨다.
5. `PostEntity`의 image 필드에 경로를 추가해준다.
6. S3 presigend url을 사용하면 많이 사용되는 방식이다.

## 이미지 업로드 엔드포인트 생성하기

자, 이제 선 업로드 방식을 위한 업로드 엔드포인트를 생성해보자.
`common` 모듈에다가 `multer` 모듈을 옮기자. 이제 `common`에서 파일 업로드를 공동으로 처리할 것이기 때문이다.

`app.module`에 있는 `multer` 관련 설정을 `common.module`로 옮겨주었다.

```ts
import { Module } from '@nestjs/common';
import { CommonService } from './common.service';
import { MulterModule } from '@nestjs/platform-express';
import { extname } from 'path';
import { v4 as uuid } from 'uuid';

@Module({
  controllers: [],
  providers: [CommonService],
  exports: [CommonService],
  imports: [
    MulterModule.register({
      limits: {
        fileSize: 1024 * 1024 * 5, // 5MB
      },
      fileFilter: (req, file, cb) => {
        if (!file.originalname.match(/\.(jpg|jpeg|png)$/)) {
          return cb(new Error('Only image files are allowed!'), false);
        }

        cb(null, true);
      },
      storage: {
        destination: (req, file, cb) => {
          cb(null, 'uploads/temp');
        },
        filename: (req, file, cb) => {
          cb(null, `${uuid()}${extname(file.originalname)}`);
        },
      },
    }),
  ],
})
export class CommonModule {}
```

이제 모든 파일 업로드는, `common`에서 처리할 것이다. 일단 이미지가 업로드되면, `temp` 폴더로 이동시켜줘야 하니, 경로를 수정해주었다.

그 다음, `common.controller`에서, 업로드되는 이미지들을 처리하는 엔드포인트를 구축해주자.

```ts
import {
  Controller,
  Post,
  UseInterceptors,
  UploadedFile,
  UseGuards,
} from '@nestjs/common';
import { CommonService } from './common.service';
import { FileInterceptor } from '@nestjs/platform-express';
import { AccessTokenGuard } from 'src/auth/guard/bearer-token.guard';

@Controller('common')
export class CommonController {
  constructor(private readonly commonService: CommonService) {}

  @Post('image')
  @UseInterceptors(FileInterceptor('image'))
  @UseGuards(AccessTokenGuard)
  postImage(@UploadedFile() file: Express.Multer.File) {
    return {
      fileName: file.filename,
    };
  }
}
```

이제, 파일을 `common/image` 엔드포인트로 업로드하면, `uploads/temp` 폴더로 이동시켜준다. 그리고, 업로드된 파일의 이름을 응답해준다.

## POST posts 엔드포인트 변경하기

common에서 이미지를 받을 것이니, posts 엔드포인트를 변경해주자. 다음과 같이 변경해주었다.

```ts
  // 컨트롤러
  @Post('/create')
  @UseGuards(AccessTokenGuard)
  create(@User('id') id, @Body() createPostDto: CreatePostDto) {
    return this.postsService.create(createPostDto, id);
  }

  // 서비스
  async create(createPostDto: CreatePostDto, userId: number) {
    const post = this.postsRepository.create({
      user: {
        id: userId,
      },
      content: createPostDto.content,
      title: createPostDto.title,
    });

    return this.postsRepository.save(post);
  }
```

image와 관련된 것들을 모두 제거해주었다. 그리고, 우리는 dto에서 이미지 프로퍼티를 하나 생성해 줄 것이다.

```ts
export class CreatePostDto extends PickType(Post, ['title', 'content']) {
  @IsString()
  @IsOptional()
  image?: string;
}
```

자, 이제 `post`를 실제로 생성하면, `temp`에 있는 이미지를 `posts`로 옮겨주어야 한다. 이것을 구현해보자.

```ts
  // posts.service
  async createPostImage(createPostDto: CreatePostDto) {
    const tempFilePath = join(PUBLIC_FOLDER_PATH, createPostDto.image);

    try {
      // 파일이 존재하는지 확인
      // 만약에 존재하지 않는다면 에러를 던짐
      await promises.access(tempFilePath);
    } catch (e) {
      throw new BadRequestException('파일이 존재하지 않습니다.');
    }

    // 파일의 이름만 가져오기
    const fileName = basename(createPostDto.image);

    // 새로 이동할 포스트 폴더의 경로 + 이미지 이름
    const newPath = join(POST_IMAGE_PATH, fileName);

    // 파일 이동
    await promises.rename(tempFilePath, newPath);

    return true;
  }
```

이렇게, temp에 있는 이미지를 posts로 옮기는 함수를 만들어 주었다. 이것을 controller에 적용시켜 보자.

```ts
  @Post('/create')
  @UseGuards(AccessTokenGuard)
  async create(@User('id') id, @Body() createPostDto: CreatePostDto) {
    if (createPostDto.image) {
      await this.postsService.createPostImage(createPostDto);
    }

    return this.postsService.create(createPostDto, id);
  }
```

적용시켰다. 이제, 이미지를 업로드하면, 파일의 이름이 리턴되고, 그것으로 dto의 image 프로퍼티를 설정한다. post를 create하면, 비로소, 이미지가 `temp`에서 `posts`로 이동된다. 그리고, post를 생성한다. 선 업로드 방식 구현 완료!

# Transaction

## Transaction 소개

트랜잭션은 데이터베이스의 상태를 변화시키기 위해 수행하는 작업의 단위이다. 트랜잭션은 데이터베이스의 무결성을 보장하기 위해, ACID라는 특성을 만족해야 한다.

start, commit, rollback으로 구성된다.

만약에 post를 생성하고, image를 생성하는데, post는 생성되었는데, image가 생성되지 않았다면, 이것은 데이터베이스의 무결성을 위배하는 것이다. 이것을 방지하기 위해, 트랜잭션을 사용해보자.

## Image Model 만들기

이미지를 지금은 한개만 받을 수 있지만, 이제 여러개 받을 수 있게 만들 것이다. post의 이미지필드를 삭제해주자. 그리고 image entity를 만들고, post와 1:N 관계를 맺어주자.

```ts
@Entity()
export class Image extends Base {
  @Column({ default: 0 })
  @IsInt()
  @IsOptional()
  order: number;

  @Column({ type: 'enum', enum: ImageType, default: ImageType.POST_IMAGE })
  type: ImageType;

  @Column()
  @IsString()
  @Transform(({ value, obj }) => {
    if (obj.type === ImageType.POST_IMAGE) {
      return join(POST_IMAGE_PATH, value);
    } else {
      return value;
    }
  })
  path: string;

  @ManyToOne(() => Post, (post) => post.images)
  post?: Post;
}
```

```ts
@Entity({ name: 'posts' })
export class Post extends Base {
  ...

  @OneToMany(() => Image, (image) => image.post, { cascade: true })
  images: Image[];
}
```

이렇게 설정해 준 다음, `app.module`에 `entities`를 추가해주자.

```ts
    ...

    TypeOrmModule.forRoot({
      type: 'postgres',
      host: '127.0.0.1',
      port: 5432,
      username: 'postgres',
      password: 'postgres',
      database: 'postgres',
      entities: [Post, User, Image],
      synchronize: true,
    }),

    ...
```

그러면 테이블 생성과 연관은 끝난 것이다.

## Image Model 생성하는 로직 작성하기.

이제 만든 Image Model을 가지고, post에서 이미지를 생성하는 부분을 고쳐주자. 우선, `createPostDto`에서, image를 여러개 받을 수 있도록 수정해주자.

```ts
export class CreatePostDto extends PickType(Post, ['title', 'content']) {
  @IsArray()
  @IsOptional()
  images?: string[] = [];
}
```

그 다음, `CreatePostImageDto`를 만들어주자.

```ts
import { PickType } from '@nestjs/mapped-types';
import { Image } from 'src/common/entities/image.entity';

export class CreatePostImageDto extends PickType(Image, [
  'path',
  'order',
  'type',
  'post',
]) {}
```

이제 이것을 기반으로, `post`의 단일 이미지 관련 함수들을 수정해줄 것이다. 일단 컨트롤러를 먼저 수정해보자.

```ts
  @Post('/create')
  @UseGuards(AccessTokenGuard)
  async create(@User('id') id, @Body() createPostDto: CreatePostDto) {
    const post = await this.postsService.create(createPostDto, id);

    for (let i = 0; i < createPostDto.images.length; i++) {
      await this.postsService.createPostImage({
        post,
        order: i,
        path: createPostDto.images[i],
        type: ImageType.POST_IMAGE,
      });
    }

    return this.postsService.findOne(post.id);
  }
```

이렇게 수정해 줬다. 루프를 돌면서, `/uploads/temp`에 생성된 이미지를 기반으로, `Image` 테이블의 row를 생성해 줄 것이다. 서비스 코드를 수정하자.

```ts
  async createPostImage(createPostImageDto: CreatePostImageDto) {
    const tempFilePath = join(PUBLIC_FOLDER_PATH, createPostImageDto.path);

    try {
      // 파일이 존재하는지 확인
      // 만약에 존재하지 않는다면 에러를 던짐
      await promises.access(tempFilePath);
    } catch (e) {
      throw new BadRequestException('파일이 존재하지 않습니다.');
    }

    // 파일의 이름만 가져오기
    const fileName = basename(tempFilePath);

    // 새로 이동할 포스트 폴더의 경로 + 이미지 이름
    const newPath = join(POST_IMAGE_PATH, fileName);

    // save
    const result = await this.imagesRepository.save({
      order: createPostImageDto.order,
      path: newPath,
      type: createPostImageDto.type,
      post: createPostImageDto.post,
    });

    // 파일 이동
    await promises.rename(tempFilePath, newPath);

    return true;
  }
```

이렇게 수정해 줬다. 이제 이미지를 업로드하면, 해당 이미지가 있는지 확인하고, `Image` 테이블에 만들어진 이미지의 정보로 row를 하나 만들어준다. 그리고, 이미지를 옮겨준다. 이제 `Transaction`을 적용해보자.

## Transaction 시작하기

post를 생성할 때 무언가 에러가 발생하면, 그 어떠한 것도 생성되지 않아야 한다. 그래서 `Transaction`을 사용해보자. `post controller`에서 다음을 주입받자.

```ts
@Controller('posts')
export class PostsController {
  constructor(
    private readonly postsService: PostsService,
    private readonly dataSource: DataSource,
  ) {}

  ...
}
```

`dataSource`로 트랜잭션과 관련된 모든 쿼리를 담당할 쿼리 러너를 생성해야 한다. 크게 어렵지 않다 예를 들어보겠다.

```ts
const qr = this.dataSource.createQueryRunner();
await qr.connect();

await qr.startTransaction();

try {
  // 쿼리 실행
  qr.getRepository(T).save(something);

  ...

  await qr.commitTransaction();
} catch (e) {
  await qr.rollbackTransaction();
} finally {
  await qr.release();
}
```

이렇게, `qr.getRepository`를 써서 쿼리를 날린 다음, 만약 에러가 발생하면 `qr.rollback`을 호출하고, 그렇지 않다면 `qr.commitTransaction`을 호출하면 된다. 그 후 `qr.release`를 호출하면 끝이다. 어렵지 않다!
