### PR TITLE
2023 11 17

### DIFF
--- a/src/auth/guard/socket/socket-bearer-token.guard.ts
+++ b/src/auth/guard/socket/socket-bearer-token.guard.ts
@@ -1,0 +1,35 @@
+import { CanActivate, ExecutionContext } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { AuthService } from 'src/auth/auth.service';
+import { UsersService } from 'src/users/users.service';
+
+export class SocketBearerTokenGuard implements CanActivate {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext) {
+    const client = context.switchToWs().getClient();
+    const headers = client.handshake.headers;
+    const rawToken = headers.authorization;
+
+    if (!rawToken) {
+      throw new WsException('Token not found');
+    }
+
+    try {
+      const token = this.authService.extractTokenFromHeader(rawToken, true);
+      const payload = this.authService.verifyToken(token);
+      const user = await this.usersService.getUserByEmail(payload.email);
+
+      client.user = user;
+      client.token = token;
+      client.tokenType = payload.type;
+
+      return true;
+    } catch (e) {
+      throw new WsException('Token is invalid');
+    }
+  }
+}

--- a/src/chats/chats.gateway.ts
+++ b/src/chats/chats.gateway.ts
@@ -12,8 +12,15 @@ import { CreateChatDto } from './dto/create-chat.dto';
 import { ChatsService } from './chats.service';
 import { CreateMessageDto } from './message/dto/create-message.dto';
 import { ChatsMessagesService } from './message/message.service';
-import { UseFilters, UsePipes, ValidationPipe } from '@nestjs/common';
+import {
+  UseFilters,
+  UseGuards,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
 import { HttpToSocketExceptionFilter } from 'src/common/exception-filter/http-to-ws.exeption-filter';
+import { SocketBearerTokenGuard } from 'src/auth/guard/socket/socket-bearer-token.guard';
+import { User } from 'src/users/entities/user.entity';
 
 @WebSocketGateway({
   namespace: 'chats',
@@ -46,10 +53,11 @@ export class ChatsGateway implements OnGatewayConnection {
     }),
   )
   @UseFilters(HttpToSocketExceptionFilter)
+  @UseGuards(SocketBearerTokenGuard)
   @SubscribeMessage('create_chat')
   async createChat(
     @MessageBody() data: CreateChatDto,
-    @ConnectedSocket() client: Socket,
+    @ConnectedSocket() client: Socket & { user: User },
   ) {
     const chat = await this.chatsService.createChat(data);
   }

--- a/src/chats/chats.gateway.ts
+++ b/src/chats/chats.gateway.ts
@@ -12,6 +12,8 @@ import { CreateChatDto } from './dto/create-chat.dto';
 import { ChatsService } from './chats.service';
 import { CreateMessageDto } from './message/dto/create-message.dto';
 import { ChatsMessagesService } from './message/message.service';
+import { UseFilters, UsePipes, ValidationPipe } from '@nestjs/common';
+import { HttpToSocketExceptionFilter } from 'src/common/exception-filter/http-to-ws.exeption-filter';
 
 @WebSocketGateway({
   namespace: 'chats',
@@ -33,6 +35,17 @@ export class ChatsGateway implements OnGatewayConnection {
     console.log(`Disconnected: ${client.id}`);
   }
 
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  )
+  @UseFilters(HttpToSocketExceptionFilter)
   @SubscribeMessage('create_chat')
   async createChat(
     @MessageBody() data: CreateChatDto,

--- a/src/chats/chats.module.ts
+++ b/src/chats/chats.module.ts
@@ -7,10 +7,17 @@ import { Chat } from './entity/chats.entity';
 import { CommonService } from 'src/common/common.service';
 import { ChatsMessagesService } from './message/message.service';
 import { Message } from './message/entity/message.entity';
+import { AuthModule } from 'src/auth/auth.module';
+import { UsersModule } from 'src/users/users.module';
 
 @Module({
   controllers: [ChatsController],
   providers: [ChatsService, ChatsGateway, ChatsMessagesService],
-  imports: [TypeOrmModule.forFeature([Chat, Message]), CommonService],
+  imports: [
+    TypeOrmModule.forFeature([Chat, Message]),
+    CommonService,
+    AuthModule,
+    UsersModule,
+  ],
 })
 export class ChatsModule {}

--- a/src/common/exception-filter/http-to-ws.exeption-filter.ts
+++ b/src/common/exception-filter/http-to-ws.exeption-filter.ts
@@ -1,0 +1,15 @@
+import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
+import { BaseWsExceptionFilter } from '@nestjs/websockets';
+
+@Catch(HttpException)
+export class HttpToSocketExceptionFilter extends BaseWsExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const client = host.switchToWs().getClient();
+
+    client.emit('exception', {
+      data: exception.getResponse(),
+      status: exception.getStatus(),
+      message: exception.message,
+    });
+  }
+}

--- a/study/2023-11-02.md
+++ b/study/2023-11-02.md
@@ -66,6 +66,23 @@ create(@Body() createCatDto: CreateCatDto) {
 }
 ```
 
+`ValidaionPipe`는 `Class Validator`와 연결이 되어서, 만약 클레스 밸리데이터로 설정된 것으로 유효하지 않은 데이터가 들어오면 에러를 응답으로 보내준다. 클래스, api 단으로 적용할 수 있고, 전역적으로 설정할 수도 있다.
+
+```ts
+app.useGlobalPipes(
+  new ValidationPipe({
+    transform: true,
+    transformOptions: {
+      enableImplicitConversion: true,
+    },
+    whitelist: true,
+    forbidNonWhitelisted: true,
+  }),
+);
+```
+
+이렇게 전역적으로 적용시켜줄 수 있다.
+
 ### 커스텀 파이프
 
 그리고 커스텀 파이프도 만들 수 있다.

--- a/study/2023-11-17.md
+++ b/study/2023-11-17.md
@@ -1,0 +1,157 @@
+# SocketIO - 심화
+
+## Valdiation Pipe
+
+게이트웨이는 rest api와 달리, 파이프가 전역적으로 적용이 안된다. 따라서 게이트웨이의 경우에는 파이프를 직접 적용해야 한다.
+
+예를 들어, 지금의 코드는 다음과 같다.
+
+```ts
+  @SubscribeMessage('create_chat')
+  async createChat(
+    @MessageBody() data: CreateChatDto,
+    @ConnectedSocket() client: Socket,
+  ) {
+    const chat = await this.chatsService.createChat(data);
+  }
+```
+
+여기서 data로 CreateChatDto에 설정되어 있는 class validator와는 다른 데이터가 들어오면 어떻게 될까? 당연히 validation pipe가 적용되어 있지 않기 때문에 서버가 터진다 ㅋㅋ. 그래서 validation pipe를 이 함수에 적용시켜야 한다. 다음처럼 말이다.
+
+```ts
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  )
+  @SubscribeMessage('create_chat')
+  async createChat(
+    @MessageBody() data: CreateChatDto,
+    @ConnectedSocket() client: Socket,
+  ) {
+    const chat = await this.chatsService.createChat(data);
+  }
+```
+
+이렇게 valididation pipe를 게이트웨이에 대해서도 적용시커 보았다. 게이트웨이에 대해서 전역적으로 적용하는 방법이 없기 때문에 이렇게 함수에 직접 적용시켜야 한다.
+
+그런데, 이렇게 해도 에러가 나면 서버가 터져버린다 왜일까?
+이유는, 에러를 http 에러를 던져서 그렇다. Websocket을 사용할 때는 WS 에러를 던져야 한다. 하지만 그렇지 않고 http 에러를 던져서 그렇다. 따라서, http 에러를 WS 에러로 변경해주는 작업을 해주어야, 오류가 사라진다.
+
+## Exception Filter 적용하기
+
+Exception filter를 이용하여 http -> ws 에러로 바꿔주도록 하자.
+
+```ts
+import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
+import { BaseWsExceptionFilter } from '@nestjs/websockets';
+
+@Catch(HttpException)
+export class HttpToSocketExceptionFilter extends BaseWsExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const client = host.switchToWs().getClient();
+
+    client.emit('exception', {
+      data: exception.getResponse(),
+      status: exception.getStatus(),
+      message: exception.message,
+    });
+  }
+}
+```
+
+이렇게 만들어 주었다. 까먹었을 수도 있어서 다시 설명하지만, 클라이언트 측에서 `exception` 이벤트를 리스닝하고 있어야 에러를 받을 수 있다. 그리고, 우리는 `excetion` 이벤트를 발생시키는 코드를 여기에 적어주면 된다. (원래는 response를 보내줘야 함)
+
+그리고 이거를 적용시켜주면 오류가 말끔히 해결된다!
+
+```ts
+  @UsePipes(
+    new ValidationPipe({
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  )
+  @UseFilters(HttpToSocketExceptionFilter)
+  @SubscribeMessage('create_chat')
+  async createChat(
+    @MessageBody() data: CreateChatDto,
+    @ConnectedSocket() client: Socket,
+  ) {
+    const chat = await this.chatsService.createChat(data);
+  }
+```
+
+이렇게 말이다!
+
+## Guard 적용하기
+
+이번에는 게이트웨이에 가드를 적용해보자.
+
+우리는 지금까지 chats 통신을 하는 녀석들이 누구인지, 검증된 유저인지 아닌지에 대해서 절차를 거치지 않고 통신을 하고 있다. 이것은 매우 위험한 일이다. 따라서, 이번에는 가드를 적용해보자.
+
+`auth/socket/socket-bearer-token.guard.ts`를 만들어주자.
+
+```ts
+import { CanActivate, ExecutionContext } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { AuthService } from 'src/auth/auth.service';
+import { UsersService } from 'src/users/users.service';
+
+export class SocketBearerTokenGuard implements CanActivate {
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService,
+  ) {}
+
+  async canActivate(context: ExecutionContext) {
+    const client = context.switchToWs().getClient();
+    const headers = client.handshake.headers;
+    const rawToken = headers.authorization;
+
+    if (!rawToken) {
+      throw new WsException('Token not found');
+    }
+
+    try {
+      const token = this.authService.extractTokenFromHeader(rawToken, true);
+      const payload = this.authService.verifyToken(token);
+      const user = await this.usersService.getUserByEmail(payload.email);
+
+      client.user = user;
+      client.token = token;
+      client.tokenType = payload.type;
+
+      return true;
+    } catch (e) {
+      throw new WsException('Token is invalid');
+    }
+  }
+}
+```
+
+이렇게, 헤더에서 토큰을 가져와서, access token 검증 후 socket에다가 우리가 request에 user 및 기타 정보를 달았던 거와 마찬가지로 정보를 달아준다. 그리고, 예외가 발생하면 웹소캣 에러를 던져야 하기 때문에 저렇게 감싼 다음 웹소켓 에러를 던저주도록 했다.
+
+## 데코레이터 기반으로 로직 변경하기
+
+## socket에 사용자 정보 저장하기
+
+## Gateway Lifecycle Hook
+
+# 모듈 네스팅
+
+# Role Based Access Control
+
+# Auhorization
+
+# Follow System
+
+# 팔로워 카운트, 코멘트 카운트 작업하기


### PR DESCRIPTION
# SocketIO - 심화

## Valdiation Pipe

게이트웨이는 rest api와 달리, 파이프가 전역적으로 적용이 안된다. 따라서 게이트웨이의 경우에는 파이프를 직접 적용해야 한다.

예를 들어, 지금의 코드는 다음과 같다.

```ts
  @SubscribeMessage('create_chat')
  async createChat(
    @MessageBody() data: CreateChatDto,
    @ConnectedSocket() client: Socket,
  ) {
    const chat = await this.chatsService.createChat(data);
  }
```

여기서 data로 CreateChatDto에 설정되어 있는 class validator와는 다른 데이터가 들어오면 어떻게 될까? 당연히 validation pipe가 적용되어 있지 않기 때문에 서버가 터진다 ㅋㅋ. 그래서 validation pipe를 이 함수에 적용시켜야 한다. 다음처럼 말이다.

```ts
  @UsePipes(
    new ValidationPipe({
      transform: true,
      transformOptions: {
        enableImplicitConversion: true,
      },
      whitelist: true,
      forbidNonWhitelisted: true,
    }),
  )
  @SubscribeMessage('create_chat')
  async createChat(
    @MessageBody() data: CreateChatDto,
    @ConnectedSocket() client: Socket,
  ) {
    const chat = await this.chatsService.createChat(data);
  }
```

이렇게 valididation pipe를 게이트웨이에 대해서도 적용시커 보았다. 게이트웨이에 대해서 전역적으로 적용하는 방법이 없기 때문에 이렇게 함수에 직접 적용시켜야 한다.

그런데, 이렇게 해도 에러가 나면 서버가 터져버린다 왜일까?
이유는, 에러를 http 에러를 던져서 그렇다. Websocket을 사용할 때는 WS 에러를 던져야 한다. 하지만 그렇지 않고 http 에러를 던져서 그렇다. 따라서, http 에러를 WS 에러로 변경해주는 작업을 해주어야, 오류가 사라진다.

## Exception Filter 적용하기

Exception filter를 이용하여 http -> ws 에러로 바꿔주도록 하자.

```ts
import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
import { BaseWsExceptionFilter } from '@nestjs/websockets';

@Catch(HttpException)
export class HttpToSocketExceptionFilter extends BaseWsExceptionFilter {
  catch(exception: HttpException, host: ArgumentsHost) {
    const client = host.switchToWs().getClient();

    client.emit('exception', {
      data: exception.getResponse(),
      status: exception.getStatus(),
      message: exception.message,
    });
  }
}
```

이렇게 만들어 주었다. 까먹었을 수도 있어서 다시 설명하지만, 클라이언트 측에서 `exception` 이벤트를 리스닝하고 있어야 에러를 받을 수 있다. 그리고, 우리는 `excetion` 이벤트를 발생시키는 코드를 여기에 적어주면 된다. (원래는 response를 보내줘야 함)

그리고 이거를 적용시켜주면 오류가 말끔히 해결된다!

```ts
  @UsePipes(
    new ValidationPipe({
      transform: true,
      transformOptions: {
        enableImplicitConversion: true,
      },
      whitelist: true,
      forbidNonWhitelisted: true,
    }),
  )
  @UseFilters(HttpToSocketExceptionFilter)
  @SubscribeMessage('create_chat')
  async createChat(
    @MessageBody() data: CreateChatDto,
    @ConnectedSocket() client: Socket,
  ) {
    const chat = await this.chatsService.createChat(data);
  }
```

이렇게 말이다!

## Guard 적용하기

이번에는 게이트웨이에 가드를 적용해보자.

우리는 지금까지 chats 통신을 하는 녀석들이 누구인지, 검증된 유저인지 아닌지에 대해서 절차를 거치지 않고 통신을 하고 있다. 이것은 매우 위험한 일이다. 따라서, 이번에는 가드를 적용해보자.

`auth/socket/socket-bearer-token.guard.ts`를 만들어주자.

```ts
import { CanActivate, ExecutionContext } from '@nestjs/common';
import { WsException } from '@nestjs/websockets';
import { AuthService } from 'src/auth/auth.service';
import { UsersService } from 'src/users/users.service';

export class SocketBearerTokenGuard implements CanActivate {
  constructor(
    private readonly authService: AuthService,
    private readonly usersService: UsersService,
  ) {}

  async canActivate(context: ExecutionContext) {
    const client = context.switchToWs().getClient();
    const headers = client.handshake.headers;
    const rawToken = headers.authorization;

    if (!rawToken) {
      throw new WsException('Token not found');
    }

    try {
      const token = this.authService.extractTokenFromHeader(rawToken, true);
      const payload = this.authService.verifyToken(token);
      const user = await this.usersService.getUserByEmail(payload.email);

      client.user = user;
      client.token = token;
      client.tokenType = payload.type;

      return true;
    } catch (e) {
      throw new WsException('Token is invalid');
    }
  }
}
```

이렇게, 헤더에서 토큰을 가져와서, access token 검증 후 socket에다가 우리가 request에 user 및 기타 정보를 달았던 거와 마찬가지로 정보를 달아준다. 그리고, 예외가 발생하면 웹소캣 에러를 던져야 하기 때문에 저렇게 감싼 다음 웹소켓 에러를 던저주도록 했다.

## 데코레이터 기반으로 로직 변경하기

## socket에 사용자 정보 저장하기

## Gateway Lifecycle Hook

# 모듈 네스팅

# Role Based Access Control

# Auhorization

# Follow System

# 팔로워 카운트, 코멘트 카운트 작업하기
